### PR TITLE
feat: add Homebrew support

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,61 @@
+name: Update Homebrew Formula
+
+on:
+  workflow_run:
+    workflows: ["Publish to PyPI"]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  update-formula:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Get release version
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name)
+          echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Wait for PyPI availability
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          for i in $(seq 1 30); do
+            if pip index versions java-functional-lsp 2>/dev/null | grep -q "$PKG_VERSION"; then
+              echo "java-functional-lsp==$PKG_VERSION available on PyPI"
+              break
+            fi
+            echo "Waiting for PyPI... attempt $i/30"
+            sleep 20
+          done
+      - name: Generate formula
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python3 scripts/generate-formula.py "$PKG_VERSION" > java-functional-lsp.rb
+          echo "Generated formula:"
+          cat java-functional-lsp.rb
+      - name: Checkout tap repo
+        uses: actions/checkout@v6
+        with:
+          repository: aviadshiber/homebrew-tap
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          path: homebrew-tap
+      - name: Update formula
+        env:
+          PKG_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cp java-functional-lsp.rb homebrew-tap/Formula/java-functional-lsp.rb
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/java-functional-lsp.rb
+          git diff --cached --quiet || git commit -m "Update java-functional-lsp to $PKG_VERSION"
+          git push

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ A Java Language Server that enforces functional programming best practices. Desi
 ## Install
 
 ```bash
+# Homebrew
+brew install aviadshiber/tap/java-functional-lsp
+
+# pip
 pip install java-functional-lsp
-```
 
-Or from source:
-
-```bash
+# From source
 pip install git+https://github.com/aviadshiber/java-functional-lsp.git
 ```
 

--- a/scripts/generate-formula.py
+++ b/scripts/generate-formula.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Generate a Homebrew formula for java-functional-lsp.
+
+Usage: python3 scripts/generate-formula.py <version>
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+
+
+def get_pypi_sha256(package: str, version: str) -> str:
+    """Get the sdist sha256 for a package from PyPI."""
+    url = f"https://pypi.org/pypi/{package}/{version}/json"
+    with urllib.request.urlopen(url) as resp:
+        data = json.loads(resp.read())
+
+    for file_info in data.get("urls", []):
+        if file_info["filename"].endswith(".tar.gz"):
+            return file_info["digests"]["sha256"]
+
+    for file_info in data.get("urls", []):
+        if file_info["packagetype"] == "sdist":
+            return file_info["digests"]["sha256"]
+
+    raise ValueError(f"No sdist found for {package}=={version}")
+
+
+def generate_formula(version: str) -> str:
+    """Generate the Homebrew formula."""
+    sha256 = get_pypi_sha256("java-functional-lsp", version)
+
+    return f'''class JavaFunctionalLsp < Formula
+  desc "Java LSP server enforcing functional programming best practices"
+  homepage "https://github.com/aviadshiber/java-functional-lsp"
+  url "https://files.pythonhosted.org/packages/source/j/java-functional-lsp/java_functional_lsp-{version}.tar.gz"
+  sha256 "{sha256}"
+  license "MIT"
+
+  depends_on "python@3.12"
+
+  def install
+    python3 = "python3.12"
+    venv = libexec/"venv"
+    system python3, "-m", "venv", venv
+    system venv/"bin/pip", "install", "--upgrade", "pip"
+    system venv/"bin/pip", "install", buildpath
+    bin.install_symlink Dir[venv/"bin/java-functional-lsp"]
+  end
+
+  test do
+    assert_match "java-functional-lsp", shell_output("#{{bin}}/java-functional-lsp --help 2>&1", 1)
+  end
+end
+'''
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <version>", file=sys.stderr)
+        sys.exit(1)
+    print(generate_formula(sys.argv[1]))


### PR DESCRIPTION
## What

Add Homebrew tap formula and auto-update workflow.

## Why

Users can now install via `brew install aviadshiber/tap/java-functional-lsp` in addition to pip.

## Changes

- `scripts/generate-formula.py` — generates Homebrew formula from PyPI metadata
- `.github/workflows/update-homebrew.yml` — auto-updates the tap after each PyPI publish
- README updated with brew install instructions

The formula is already live at `aviadshiber/homebrew-tap`.

## Checklist

- [x] Tests added/updated (no new tests needed — infrastructure only)
- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run mypy src/` passes
- [x] `uv run pytest` passes
- [x] Documentation updated