### PR TITLE
fix: run release-drafter only on push to main

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,8 +3,6 @@ name: Release Drafter
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: write


### PR DESCRIPTION
Remove pull_request trigger from release-drafter workflow. It only needs to run when PRs are merged to main, not on every PR update. This eliminates the false CI failures on PRs.