### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.1.0"
+version = "0.2.0"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -40,7 +40,9 @@ _converter = cattrs.Converter()
 
 class JavaFunctionalLspServer(LanguageServer):
     def __init__(self) -> None:
-        super().__init__("java-functional-lsp", "0.1.0")
+        from . import __version__
+
+        super().__init__("java-functional-lsp", __version__)
         self._parser = get_parser()
         self._config: dict[str, Any] = {}
         self._init_params: dict[str, Any] = {}

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
Bump version for the jdtls proxy release. Also removes hardcoded version from server.py — reads from `__init__.__version__` instead.