### PR TITLE
fix: add jdtls as recommended dep in Homebrew formula

### DIFF
--- a/scripts/generate-formula.py
+++ b/scripts/generate-formula.py
@@ -39,6 +39,7 @@ def generate_formula(version: str) -> str:
   license "MIT"
 
   depends_on "python@3.12"
+  depends_on "jdtls" => :recommended
 
   def install
     python3 = "python3.12"


### PR DESCRIPTION
Ensures future auto-generated formulas include `depends_on "jdtls" => :recommended` so jdtls auto-installs with the package.