### PR TITLE
feat: reduce false positives — excludes, @Bean, @ConfigurationProperties

### DIFF
--- a/src/java_functional_lsp/analyzers/base.py
+++ b/src/java_functional_lsp/analyzers/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 from collections.abc import Generator
 from dataclasses import dataclass
 from enum import IntEnum
@@ -147,3 +148,26 @@ def severity_from_config(config: dict[str, Any], rule_id: str, default: Severity
         "info": Severity.INFO,
         "hint": Severity.HINT,
     }.get(level, default)
+
+
+def is_excluded(path_str: str, patterns: list[str]) -> bool:
+    """Return True if path matches any exclude glob pattern.
+
+    Patterns support ** for multi-segment wildcards (e.g. **/generated/**).
+    Uses fnmatch which handles ** correctly across Python 3.10+.
+    """
+    normalized = path_str.replace("\\", "/")
+    return any(fnmatch.fnmatch(normalized, pattern) for pattern in patterns)
+
+
+def has_sibling_annotation(modifiers_node: Node, annotation_name: bytes) -> bool:
+    """Check if a modifiers node contains an annotation with the given name.
+
+    Checks both marker_annotation (@Foo) and annotation (@Foo(...)) forms.
+    """
+    for child in modifiers_node.named_children:
+        if child.type in ("marker_annotation", "annotation"):
+            name_node = child.child_by_field_name("name")
+            if name_node is not None and name_node.text == annotation_name:
+                return True
+    return False

--- a/src/java_functional_lsp/analyzers/exception_checker.py
+++ b/src/java_functional_lsp/analyzers/exception_checker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import Diagnostic, find_nodes, severity_from_config
+from .base import Diagnostic, find_nodes, has_sibling_annotation, severity_from_config
 
 _MESSAGES = {
     "throw-statement": ("Avoid throwing exceptions. Use Either.left(error) or Try.of(() -> ...).toEither()."),
@@ -12,6 +12,19 @@ _MESSAGES = {
         "Avoid catching and rethrowing. Use Try.of(() -> ...).toEither() to convert exceptions to values."
     ),
 }
+
+
+def _is_in_bean_method(node: Any) -> bool:
+    """Check if node is inside a method annotated with @Bean."""
+    parent = node.parent
+    while parent:
+        if parent.type == "method_declaration":
+            modifiers = next((c for c in parent.children if c.type == "modifiers"), None)
+            if modifiers and has_sibling_annotation(modifiers, b"Bean"):
+                return True
+            return False
+        parent = parent.parent
+    return False
 
 
 class ExceptionChecker:
@@ -24,6 +37,8 @@ class ExceptionChecker:
         severity = severity_from_config(config, "throw-statement")
         if severity is not None:
             for node in find_nodes(tree.root_node, "throw_statement"):
+                if _is_in_bean_method(node):
+                    continue
                 diagnostics.append(
                     Diagnostic(
                         line=node.start_point[0],
@@ -40,10 +55,11 @@ class ExceptionChecker:
         severity = severity_from_config(config, "catch-rethrow")
         if severity is not None:
             for node in find_nodes(tree.root_node, "catch_clause"):
+                if _is_in_bean_method(node):
+                    continue
                 body = node.child_by_field_name("body")
                 if body is None:
                     continue
-                # Check if the block has exactly one named statement and it's a throw
                 statements = [c for c in body.named_children if c.type not in ("line_comment", "block_comment")]
                 if len(statements) == 1 and statements[0].type == "throw_statement":
                     diagnostics.append(

--- a/src/java_functional_lsp/analyzers/mutation_checker.py
+++ b/src/java_functional_lsp/analyzers/mutation_checker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import Diagnostic, find_nodes, find_nodes_multi, has_ancestor, severity_from_config
+from .base import Diagnostic, find_nodes, find_nodes_multi, has_ancestor, has_sibling_annotation, severity_from_config
 
 _MESSAGES = {
     "mutable-variable": "Avoid reassigning variables. Use final + functional transforms (map, flatMap, fold).",
@@ -45,8 +45,15 @@ class MutationChecker:
             if ann_text in (b"Data", b"Setter"):
                 # Verify it's on a class declaration
                 if node.parent and node.parent.type == "modifiers":
-                    grandparent = node.parent.parent
+                    modifiers = node.parent
+                    grandparent = modifiers.parent
                     if grandparent and grandparent.type == "class_declaration":
+                        if has_sibling_annotation(modifiers, b"ConfigurationProperties"):
+                            message = (
+                                "Use @ConstructorBinding instead of @Data/@Setter for @ConfigurationProperties classes."
+                            )
+                        else:
+                            message = _MESSAGES["mutable-dto"]
                         diagnostics.append(
                             Diagnostic(
                                 line=name_node.start_point[0],
@@ -55,7 +62,7 @@ class MutationChecker:
                                 end_col=name_node.end_point[1],
                                 severity=severity,
                                 code="mutable-dto",
-                                message=_MESSAGES["mutable-dto"],
+                                message=message,
                             )
                         )
 

--- a/src/java_functional_lsp/cli.py
+++ b/src/java_functional_lsp/cli.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from .analyzers.base import Analyzer, Diagnostic, Severity, get_parser
+from .analyzers.base import Analyzer, Diagnostic, Severity, get_parser, is_excluded
 from .analyzers.exception_checker import ExceptionChecker
 from .analyzers.mutation_checker import MutationChecker
 from .analyzers.null_checker import NullChecker
@@ -107,7 +107,10 @@ def main() -> None:
     config = load_config(files[0])
 
     total_diags = 0
+    excludes: list[str] = config.get("excludes", [])
     for path in files:
+        if excludes and is_excluded(path.as_posix(), excludes):
+            continue
         diags = check_file(path, config)
         for d in diags:
             print(format_diagnostic(path, d))

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -16,7 +16,7 @@ import cattrs
 from lsprotocol import types as lsp
 from pygls.lsp.server import LanguageServer
 
-from .analyzers.base import Analyzer, Severity, get_parser
+from .analyzers.base import Analyzer, Severity, get_parser, is_excluded
 from .analyzers.base import Diagnostic as LintDiagnostic
 from .analyzers.exception_checker import ExceptionChecker
 from .analyzers.mutation_checker import MutationChecker
@@ -96,6 +96,13 @@ def _to_lsp_diagnostic(diag: LintDiagnostic) -> lsp.Diagnostic:
 
 def _analyze_document(source_text: str, uri: str = "") -> list[lsp.Diagnostic]:
     """Run all custom analyzers on the given source text. Uses incremental parsing when possible."""
+    # Check excludes before parsing
+    if uri:
+        excludes: list[str] = server._config.get("excludes", [])
+        if excludes:
+            path_str = uri.replace("file://", "")
+            if is_excluded(path_str, excludes):
+                return []
     source_bytes = source_text.encode("utf-8")
     old_tree = server._trees.get(uri) if uri else None
     tree = server._parser.parse(source_bytes, old_tree) if old_tree else server._parser.parse(source_bytes)

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -100,7 +100,7 @@ def _analyze_document(source_text: str, uri: str = "") -> list[lsp.Diagnostic]:
     if uri:
         excludes: list[str] = server._config.get("excludes", [])
         if excludes:
-            path_str = uri.replace("file://", "")
+            path_str = _uri_to_path(uri)
             if is_excluded(path_str, excludes):
                 return []
     source_bytes = source_text.encode("utf-8")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,6 +7,8 @@ from java_functional_lsp.analyzers.base import (
     find_nodes_multi,
     get_parser,
     has_ancestor,
+    has_sibling_annotation,
+    is_excluded,
 )
 
 
@@ -120,3 +122,36 @@ class TestCollectNodesByType:
         buckets = collect_nodes_by_type(tree.root_node, {"null_literal", "throw_statement"})
         assert len(buckets["null_literal"]) == 0
         assert len(buckets["throw_statement"]) == 0
+
+
+class TestIsExcluded:
+    def test_matches_double_star_pattern(self):
+        assert is_excluded("/home/user/project/nlu-trs-client-shaded/Foo.java", ["**/nlu-trs-client-shaded/**"])
+
+    def test_no_match(self):
+        assert not is_excluded("/home/user/project/src/Foo.java", ["**/nlu-trs-client-shaded/**"])
+
+    def test_empty_patterns(self):
+        assert not is_excluded("/any/path/Foo.java", [])
+
+    def test_multiple_patterns(self):
+        assert is_excluded("/project/generated/Model.java", ["**/shaded/**", "**/generated/**"])
+
+    def test_windows_backslashes_normalized(self):
+        assert is_excluded("C:\\project\\generated\\Model.java", ["**/generated/**"])
+
+
+class TestHasSiblingAnnotation:
+    def test_finds_sibling_annotation(self):
+        tree = _parse("@ConfigurationProperties @Setter class Props { String name; }")
+        for node in find_nodes(tree.root_node, "marker_annotation"):
+            name = node.child_by_field_name("name")
+            if name and name.text == b"Setter" and node.parent:
+                assert has_sibling_annotation(node.parent, b"ConfigurationProperties")
+
+    def test_no_sibling(self):
+        tree = _parse("@Setter class Props { String name; }")
+        for node in find_nodes(tree.root_node, "marker_annotation"):
+            name = node.child_by_field_name("name")
+            if name and name.text == b"Setter" and node.parent:
+                assert not has_sibling_annotation(node.parent, b"ConfigurationProperties")

--- a/tests/test_exception_checker.py
+++ b/tests/test_exception_checker.py
@@ -60,3 +60,45 @@ class TestCatchRethrow:
         """
         diags = parse_and_analyze(ExceptionChecker(), source)
         assert not any(d.code == "catch-rethrow" for d in diags)
+
+
+class TestBeanSuppression:
+    def test_ignores_throw_in_bean_method(self) -> None:
+        source = b"""
+        class Config {
+            @Bean
+            DataSource dataSource() {
+                if (url == null) {
+                    throw new IllegalStateException("url required");
+                }
+                return new DataSource(url);
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert not any(d.code == "throw-statement" for d in diags)
+
+    def test_flags_throw_in_regular_method(self) -> None:
+        source = b"""
+        class Service {
+            void process() {
+                throw new RuntimeException("error");
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert any(d.code == "throw-statement" for d in diags)
+
+    def test_ignores_catch_rethrow_in_bean_method(self) -> None:
+        source = b"""
+        class Config {
+            @Bean
+            DataSource dataSource() {
+                try { return connect(); }
+                catch (Exception e) { throw new RuntimeException(e); }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert not any(d.code == "catch-rethrow" for d in diags)
+        assert not any(d.code == "throw-statement" for d in diags)

--- a/tests/test_mutation_checker.py
+++ b/tests/test_mutation_checker.py
@@ -58,6 +58,20 @@ class TestMutableDto:
         diags = parse_and_analyze(MutationChecker(), source)
         assert not any(d.code == "mutable-dto" for d in diags)
 
+    def test_config_properties_suggests_constructor_binding(self) -> None:
+        source = b"@ConfigurationProperties @Setter class Props { String name; }"
+        diags = parse_and_analyze(MutationChecker(), source)
+        dto_diags = [d for d in diags if d.code == "mutable-dto"]
+        assert len(dto_diags) == 1
+        assert "@ConstructorBinding" in dto_diags[0].message
+
+    def test_regular_setter_suggests_value(self) -> None:
+        source = b"@Setter class Foo { String name; }"
+        diags = parse_and_analyze(MutationChecker(), source)
+        dto_diags = [d for d in diags if d.code == "mutable-dto"]
+        assert len(dto_diags) == 1
+        assert "@Value" in dto_diags[0].message
+
 
 class TestImperativeOptionUnwrap:
     def test_detects_is_defined_get(self) -> None:


### PR DESCRIPTION
## Summary

3 changes to reduce false positives found during real-world code review:

1. **Path-based excludes** — `"excludes": ["**/shaded/**"]` in `.java-functional-lsp.json` skips entire directories
2. **@Bean suppression** — `throw-statement` and `catch-rethrow` suppressed inside `@Bean` methods (Spring requires exceptions for context init)
3. **@ConfigurationProperties message** — `mutable-dto` suggests `@ConstructorBinding` instead of `@Value` when the class has `@ConfigurationProperties`

## Test plan

- [x] 98 tests pass (coverage 66%)
- [x] Ruff: all checks passed
- [x] Mypy: no issues
- [x] Manual: `SignatureVaultProperties.java` shows @ConstructorBinding message
- [x] Manual: @Bean method throws correctly suppressed
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)