### PR TITLE
docs: document excludes, @Bean suppression, @ConfigurationProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Create `.java-functional-lsp.json` in your project root to customize rules:
 
 ```json
 {
+  "excludes": ["**/generated/**", "**/vendor/**"],
   "rules": {
     "null-literal-arg": "warning",
     "throw-statement": "info",
@@ -127,8 +128,13 @@ Create `.java-functional-lsp.json` in your project root to customize rules:
 }
 ```
 
-Severity levels: `error`, `warning`, `info`, `hint`, `off`.
-All rules default to `warning` when not configured.
+**Options:**
+- `excludes` — glob patterns for files/directories to skip entirely (supports `**` for multi-segment wildcards)
+- `rules` — per-rule severity: `error`, `warning` (default), `info`, `hint`, `off`
+
+**Spring-aware behavior:**
+- `throw-statement` and `catch-rethrow` are automatically suppressed inside `@Bean` methods
+- `mutable-dto` suggests `@ConstructorBinding` instead of `@Value` when the class has `@ConfigurationProperties`
 
 ## How it works
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -45,6 +45,7 @@ Create `.java-functional-lsp.json` in your project root:
 
 ```json
 {
+  "excludes": ["**/generated/**", "**/vendor/**"],
   "rules": {
     "imperative-loop": "hint",
     "mutable-variable": "info",
@@ -53,7 +54,10 @@ Create `.java-functional-lsp.json` in your project root:
 }
 ```
 
-Severity levels: `error`, `warning` (default), `info`, `hint`, `off`.
+- `excludes` — glob patterns to skip files/directories entirely
+- `rules` — per-rule severity: `error`, `warning` (default), `info`, `hint`, `off`
+- `throw-statement`/`catch-rethrow` auto-suppressed in `@Bean` methods
+- `mutable-dto` suggests `@ConstructorBinding` for `@ConfigurationProperties` classes
 
 ## On-Demand Linting
 


### PR DESCRIPTION
Documents the 3 new features from PR #17:
- `excludes` glob patterns in config
- @Bean method suppression for throw/catch rules
- @ConfigurationProperties-aware mutable-dto message

🤖 Generated with [Claude Code](https://claude.com/claude-code)