### PR TITLE
docs: document project-level .lsp.json for containers and CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ Or manually add to your Claude Code config:
 }
 ```
 
+**Alternative: project-level `.lsp.json`** — instead of installing the plugin or editing global config, add a `.lsp.json` file at your project root:
+
+```json
+{
+  "java-functional": {
+    "command": "java-functional-lsp",
+    "extensionToLanguage": { ".java": "java" }
+  }
+}
+```
+
+This is useful for CI environments, containers, or ensuring all team members get the LSP server without individual setup. The `java-functional-lsp` binary must still be installed (`pip install java-functional-lsp` or `brew install aviadshiber/tap/java-functional-lsp`).
+
 **Step 3: Nudge Claude to prefer LSP** (recommended):
 
 Add to `~/.claude/rules/code-intelligence.md`:

--- a/SKILL.md
+++ b/SKILL.md
@@ -85,6 +85,11 @@ LSP support requires `ENABLE_LSP_TOOL=1` in `~/.claude/settings.json`:
 { "env": { "ENABLE_LSP_TOOL": "1" } }
 ```
 
+For containers or CI, add a `.lsp.json` at the project root instead of installing the plugin:
+```json
+{ "java-functional": { "command": "java-functional-lsp", "extensionToLanguage": { ".java": "java" } } }
+```
+
 To nudge Claude to act on diagnostics, add to your project's `CLAUDE.md`:
 ```
 After writing or editing Java code, check LSP diagnostics before moving on.


### PR DESCRIPTION
## Summary

- Document `.lsp.json` as an alternative to plugin installation or global config in README.md
- Add brief mention in SKILL.md for containers/CI environments
- Useful for Kapsis containers, CI, and team-wide LSP setup without individual configuration

## Test plan

- [ ] Verify `.lsp.json` example is valid JSON
- [ ] Confirm docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)