### PR TITLE
feat: add E2E tests, fix incremental parsing and thread-safety bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ Or manually add to your Claude Code config:
 }
 ```
 
+**Alternative: project-level `.lsp.json`** — instead of installing the plugin or editing global config, add a `.lsp.json` file at your project root:
+
+```json
+{
+  "java-functional": {
+    "command": "java-functional-lsp",
+    "extensionToLanguage": { ".java": "java" }
+  }
+}
+```
+
+This is useful for CI environments, containers, or ensuring all team members get the LSP server without individual setup. The `java-functional-lsp` binary must still be installed (`pip install java-functional-lsp` or `brew install aviadshiber/tap/java-functional-lsp`).
+
 **Step 3: Nudge Claude to prefer LSP** (recommended):
 
 Add to `~/.claude/rules/code-intelligence.md`:

--- a/SKILL.md
+++ b/SKILL.md
@@ -85,6 +85,11 @@ LSP support requires `ENABLE_LSP_TOOL=1` in `~/.claude/settings.json`:
 { "env": { "ENABLE_LSP_TOOL": "1" } }
 ```
 
+For containers or CI, add a `.lsp.json` at the project root instead of installing the plugin:
+```json
+{ "java-functional": { "command": "java-functional-lsp", "extensionToLanguage": { ".java": "java" } } }
+```
+
 To nudge Claude to act on diagnostics, add to your project's `CLAUDE.md`:
 ```
 After writing or editing Java code, check LSP diagnostics before moving on.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^18.19.130",
         "@types/vscode": "^1.75.0",
         "@vscode/vsce": "^3.0.0",
+        "esbuild": "^0.27.4",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -230,6 +231,448 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1571,6 +2014,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "http://artifactory-build.taboolasyndication.com:80/artifactory/api/npm/npm-public/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
       }
     },
     "node_modules/expand-template": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "pytest-mock>=3.12.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
+    "pytest-timeout>=2.4.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/java_functional_lsp/__main__.py
+++ b/src/java_functional_lsp/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running as ``python -m java_functional_lsp``."""
+
+from .cli import main
+
+main()

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -48,7 +48,7 @@ class JavaFunctionalLspServer(LanguageServer):
         self._parser = get_parser()
         self._config: dict[str, Any] = {}
         self._init_params: dict[str, Any] = {}
-        self._trees: dict[str, Any] = {}  # URI -> last parsed tree for incremental parsing
+        self._trees: dict[str, Any] = {}  # URI -> state for didClose cleanup
         self._proxy = JdtlsProxy(on_diagnostics=self._on_jdtls_diagnostics)
 
     def _on_jdtls_diagnostics(self, uri: str, diagnostics: list[Any]) -> None:
@@ -103,7 +103,7 @@ def _to_lsp_diagnostic(diag: LintDiagnostic) -> lsp.Diagnostic:
 
 
 def _analyze_document(source_text: str, uri: str = "") -> list[lsp.Diagnostic]:
-    """Run all custom analyzers on the given source text. Uses incremental parsing when possible."""
+    """Run all custom analyzers on the given source text."""
     # Check excludes before parsing
     if uri:
         excludes: list[str] = server._config.get("excludes", [])
@@ -112,10 +112,9 @@ def _analyze_document(source_text: str, uri: str = "") -> list[lsp.Diagnostic]:
             if is_excluded(path_str, excludes):
                 return []
     source_bytes = source_text.encode("utf-8")
-    old_tree = server._trees.get(uri) if uri else None
-    tree = server._parser.parse(source_bytes, old_tree) if old_tree else server._parser.parse(source_bytes)
-    if uri:
-        server._trees[uri] = tree
+    # Always do a fresh parse — incremental parsing requires tree.edit() with
+    # exact byte offsets, which we don't track under Full document sync.
+    tree = server._parser.parse(source_bytes)
     config = server._config
 
     all_diagnostics: list[LintDiagnostic] = []
@@ -159,18 +158,22 @@ def _jdtls_raw_to_lsp_diagnostics(raw_diagnostics: list[Any]) -> list[lsp.Diagno
     return result
 
 
-def _publish_diagnostics(uri: str) -> None:
-    """Merge custom + jdtls diagnostics and publish to client."""
-    doc = server.workspace.get_text_document(uri)
-    custom_diags = _analyze_document(doc.source, uri)
+def _run_analysis(source: str, uri: str) -> list[lsp.Diagnostic]:
+    """Run custom analyzers on source text (thread-safe, no workspace access)."""
+    custom_diags = _analyze_document(source, uri)
 
-    # Get cached jdtls diagnostics
     jdtls_diags: list[lsp.Diagnostic] = []
     if server._proxy.is_available:
         raw = server._proxy.get_cached_diagnostics(uri)
         jdtls_diags = _jdtls_raw_to_lsp_diagnostics(raw)
 
-    merged = jdtls_diags + custom_diags
+    return jdtls_diags + custom_diags
+
+
+def _publish_diagnostics(uri: str) -> None:
+    """Read document source and publish diagnostics (call from event loop only)."""
+    doc = server.workspace.get_text_document(uri)
+    merged = _run_analysis(doc.source, uri)
     server.text_document_publish_diagnostics(lsp.PublishDiagnosticsParams(uri=uri, diagnostics=merged))
 
 
@@ -231,10 +234,17 @@ async def on_initialized(params: lsp.InitializedParams) -> None:
 # --- Document sync (forward to jdtls + run custom analyzers) ---
 
 
+def _analyze_and_publish(uri: str) -> None:
+    """Read document source, run analysis, publish results."""
+    doc = server.workspace.get_text_document(uri)
+    diagnostics = _run_analysis(doc.source, uri)
+    server.text_document_publish_diagnostics(lsp.PublishDiagnosticsParams(uri=uri, diagnostics=diagnostics))
+
+
 async def _deferred_validate(uri: str) -> None:
     """Debounced validation — waits before analyzing to batch rapid edits."""
     await asyncio.sleep(_DEBOUNCE_SECONDS)
-    await asyncio.to_thread(_publish_diagnostics, uri)
+    _analyze_and_publish(uri)
 
 
 @server.feature(lsp.TEXT_DOCUMENT_DID_OPEN)
@@ -242,7 +252,7 @@ async def on_did_open(params: lsp.DidOpenTextDocumentParams) -> None:
     """Forward to jdtls and analyze immediately."""
     if server._proxy.is_available:
         await server._proxy.send_notification("textDocument/didOpen", _serialize_params(params))
-    await asyncio.to_thread(_publish_diagnostics, params.text_document.uri)
+    _analyze_and_publish(params.text_document.uri)
 
 
 @server.feature(lsp.TEXT_DOCUMENT_DID_CHANGE)
@@ -262,7 +272,7 @@ async def on_did_save(params: lsp.DidSaveTextDocumentParams) -> None:
     """Forward to jdtls and re-analyze immediately (no debounce on save)."""
     if server._proxy.is_available:
         await server._proxy.send_notification("textDocument/didSave", _serialize_params(params))
-    await asyncio.to_thread(_publish_diagnostics, params.text_document.uri)
+    _analyze_and_publish(params.text_document.uri)
 
 
 @server.feature(lsp.TEXT_DOCUMENT_DID_CLOSE)

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -48,13 +48,12 @@ class JavaFunctionalLspServer(LanguageServer):
         self._parser = get_parser()
         self._config: dict[str, Any] = {}
         self._init_params: dict[str, Any] = {}
-        self._trees: dict[str, Any] = {}  # URI -> state for didClose cleanup
         self._proxy = JdtlsProxy(on_diagnostics=self._on_jdtls_diagnostics)
 
     def _on_jdtls_diagnostics(self, uri: str, diagnostics: list[Any]) -> None:
         """Called when jdtls publishes diagnostics — merge with custom and re-publish."""
         try:
-            _publish_diagnostics(uri)
+            _analyze_and_publish(uri)
         except Exception as e:
             logger.error("Error re-publishing diagnostics for %s: %s", uri, e)
 
@@ -159,7 +158,7 @@ def _jdtls_raw_to_lsp_diagnostics(raw_diagnostics: list[Any]) -> list[lsp.Diagno
 
 
 def _run_analysis(source: str, uri: str) -> list[lsp.Diagnostic]:
-    """Run custom analyzers on source text (thread-safe, no workspace access)."""
+    """Run custom analyzers on source text and merge with jdtls diagnostics."""
     custom_diags = _analyze_document(source, uri)
 
     jdtls_diags: list[lsp.Diagnostic] = []
@@ -168,13 +167,6 @@ def _run_analysis(source: str, uri: str) -> list[lsp.Diagnostic]:
         jdtls_diags = _jdtls_raw_to_lsp_diagnostics(raw)
 
     return jdtls_diags + custom_diags
-
-
-def _publish_diagnostics(uri: str) -> None:
-    """Read document source and publish diagnostics (call from event loop only)."""
-    doc = server.workspace.get_text_document(uri)
-    merged = _run_analysis(doc.source, uri)
-    server.text_document_publish_diagnostics(lsp.PublishDiagnosticsParams(uri=uri, diagnostics=merged))
 
 
 def _serialize_params(params: Any) -> Any:
@@ -279,7 +271,6 @@ async def on_did_save(params: lsp.DidSaveTextDocumentParams) -> None:
 async def on_did_close(params: lsp.DidCloseTextDocumentParams) -> None:
     """Clean up cached state and forward to jdtls."""
     uri = params.text_document.uri
-    server._trees.pop(uri, None)
     if uri in _pending:
         _pending[uri].cancel()
         del _pending[uri]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -73,7 +73,10 @@ def server():
         proc.wait(timeout=5)
     except (BrokenPipeError, OSError, subprocess.TimeoutExpired):
         proc.kill()
-        proc.wait(timeout=2)
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            pass
 
 
 def _initialize(proc: subprocess.Popen[bytes], root_uri: str = "file:///tmp") -> dict[str, Any] | None:
@@ -159,6 +162,10 @@ def _wait_diagnostics(proc: subprocess.Popen[bytes]) -> dict[str, Any] | None:
     return _read_until_method(proc, "textDocument/publishDiagnostics")
 
 
+# Per-test timeout prevents CI from hanging if the server crashes mid-test
+pytestmark = pytest.mark.timeout(15)
+
+
 class TestE2EInitialize:
     def test_server_capabilities(self, server: subprocess.Popen[bytes]) -> None:
         """Server should advertise text document sync capability."""
@@ -221,14 +228,17 @@ class TestE2EDiagnostics:
 
         _did_change(server, uri, "class T { String f() { return null; } }")
         _did_save(server, uri)
-        # May receive multiple notifications (debounce + save) — find one with violations
+        # May receive multiple notifications (debounce + save) — collect all codes seen
+        all_codes: set[str] = set()
         for _ in range(5):
             msg = _wait_diagnostics(server)
-            assert msg is not None
-            codes = [d["code"] for d in msg["params"]["diagnostics"]]
-            if "null-return" in codes:
+            if msg is None:
                 break
-        assert "null-return" in codes
+            for d in msg["params"]["diagnostics"]:
+                all_codes.add(d["code"])
+            if "null-return" in all_codes:
+                break
+        assert "null-return" in all_codes, f"Expected null-return, got {all_codes}"
 
     def test_diagnostics_on_save(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
         """Save should trigger immediate diagnostics."""

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,341 @@
+"""End-to-end tests: start the LSP server over stdio, send real JSON-RPC messages, verify diagnostics."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _encode_lsp(obj: dict[str, Any]) -> bytes:
+    """Encode a JSON-RPC message with Content-Length header."""
+    body = json.dumps(obj).encode("utf-8")
+    return f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+
+
+def _read_lsp(proc: subprocess.Popen[bytes]) -> dict[str, Any] | None:
+    """Read one LSP message from the server's stdout."""
+    assert proc.stdout is not None
+    headers: dict[str, str] = {}
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            return None
+        line_str = line.decode("ascii").strip()
+        if line_str == "":
+            break
+        key, _, value = line_str.partition(": ")
+        headers[key] = value
+    length = int(headers.get("Content-Length", "0"))
+    if length == 0:
+        return None
+    body = proc.stdout.read(length)
+    return json.loads(body)
+
+
+def _send(proc: subprocess.Popen[bytes], msg: dict[str, Any]) -> None:
+    """Send an LSP message to the server."""
+    assert proc.stdin is not None
+    proc.stdin.write(_encode_lsp(msg))
+    proc.stdin.flush()
+
+
+def _read_until_method(proc: subprocess.Popen[bytes], method: str, max_messages: int = 20) -> dict[str, Any] | None:
+    """Read messages until one with the given method appears."""
+    for _ in range(max_messages):
+        msg = _read_lsp(proc)
+        if msg is None:
+            return None
+        if msg.get("method") == method:
+            return msg
+    return None
+
+
+@pytest.fixture
+def server():
+    """Start the LSP server as a subprocess, shut down cleanly after test."""
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "java_functional_lsp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    yield proc
+    # Graceful LSP shutdown: send shutdown request, then exit notification
+    try:
+        _send(proc, {"jsonrpc": "2.0", "id": 9999, "method": "shutdown", "params": None})
+        _read_lsp(proc)  # consume shutdown response
+        _send(proc, {"jsonrpc": "2.0", "method": "exit", "params": None})
+        proc.wait(timeout=5)
+    except (BrokenPipeError, OSError, subprocess.TimeoutExpired):
+        proc.kill()
+        proc.wait(timeout=2)
+
+
+def _initialize(proc: subprocess.Popen[bytes], root_uri: str = "file:///tmp") -> dict[str, Any] | None:
+    """Send initialize + initialized, return the initialize response."""
+    _send(
+        proc,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "processId": None,
+                "capabilities": {},
+                "rootUri": root_uri,
+            },
+        },
+    )
+    response = _read_lsp(proc)
+    _send(proc, {"jsonrpc": "2.0", "method": "initialized", "params": {}})
+    return response
+
+
+def _did_open(proc: subprocess.Popen[bytes], uri: str, text: str, version: int = 1) -> None:
+    """Send textDocument/didOpen notification."""
+    _send(
+        proc,
+        {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "java",
+                    "version": version,
+                    "text": text,
+                }
+            },
+        },
+    )
+
+
+def _did_change(proc: subprocess.Popen[bytes], uri: str, text: str, version: int = 2) -> None:
+    """Send textDocument/didChange notification with full content."""
+    _send(
+        proc,
+        {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+                "textDocument": {"uri": uri, "version": version},
+                "contentChanges": [{"text": text}],
+            },
+        },
+    )
+
+
+def _did_close(proc: subprocess.Popen[bytes], uri: str) -> None:
+    """Send textDocument/didClose notification."""
+    _send(
+        proc,
+        {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {"textDocument": {"uri": uri}},
+        },
+    )
+
+
+def _did_save(proc: subprocess.Popen[bytes], uri: str) -> None:
+    """Send textDocument/didSave notification."""
+    _send(
+        proc,
+        {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didSave",
+            "params": {"textDocument": {"uri": uri}},
+        },
+    )
+
+
+def _wait_diagnostics(proc: subprocess.Popen[bytes]) -> dict[str, Any] | None:
+    """Wait for a publishDiagnostics notification."""
+    return _read_until_method(proc, "textDocument/publishDiagnostics")
+
+
+class TestE2EInitialize:
+    def test_server_capabilities(self, server: subprocess.Popen[bytes]) -> None:
+        """Server should advertise text document sync capability."""
+        response = _initialize(server)
+        assert response is not None
+        result = response.get("result", {})
+        caps = result.get("capabilities", {})
+        assert "textDocumentSync" in caps
+
+    def test_server_name(self, server: subprocess.Popen[bytes]) -> None:
+        """Server should identify itself."""
+        response = _initialize(server)
+        assert response is not None
+        info = response["result"].get("serverInfo", {})
+        assert "java-functional" in info.get("name", "").lower()
+
+
+class TestE2EDiagnostics:
+    def test_diagnostics_on_open(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
+        """Opening a Java file with null return should produce diagnostics."""
+        java_file = tmp_path / "Test.java"
+        java_file.write_text("class T { String f() { return null; } }")
+        uri = java_file.as_uri()
+
+        _initialize(server, root_uri=tmp_path.as_uri())
+        _did_open(server, uri, java_file.read_text())
+
+        msg = _wait_diagnostics(server)
+        assert msg is not None
+        params = msg["params"]
+        assert params["uri"] == uri
+        codes = [d["code"] for d in params["diagnostics"]]
+        assert "null-return" in codes
+
+    def test_clean_file_no_diagnostics(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
+        """A clean Java file should produce empty diagnostics."""
+        java_file = tmp_path / "Clean.java"
+        java_file.write_text('class T { String f() { return "ok"; } }')
+        uri = java_file.as_uri()
+
+        _initialize(server, root_uri=tmp_path.as_uri())
+        _did_open(server, uri, java_file.read_text())
+
+        msg = _wait_diagnostics(server)
+        assert msg is not None
+        assert len(msg["params"]["diagnostics"]) == 0
+
+    def test_diagnostics_on_change(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
+        """Editing a file to introduce a violation should produce diagnostics.
+
+        didChange is debounced (150ms), so we follow with didSave for immediate results.
+        """
+        java_file = tmp_path / "Change.java"
+        java_file.write_text('class T { String f() { return "ok"; } }')
+        uri = java_file.as_uri()
+
+        _initialize(server, root_uri=tmp_path.as_uri())
+        _did_open(server, uri, java_file.read_text())
+        _wait_diagnostics(server)  # consume initial clean diagnostics
+
+        _did_change(server, uri, "class T { String f() { return null; } }")
+        _did_save(server, uri)
+        # May receive multiple notifications (debounce + save) — find one with violations
+        for _ in range(5):
+            msg = _wait_diagnostics(server)
+            assert msg is not None
+            codes = [d["code"] for d in msg["params"]["diagnostics"]]
+            if "null-return" in codes:
+                break
+        assert "null-return" in codes
+
+    def test_diagnostics_on_save(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
+        """Save should trigger immediate diagnostics."""
+        java_file = tmp_path / "Save.java"
+        java_file.write_text("class T { void f() { throw new RuntimeException(); } }")
+        uri = java_file.as_uri()
+
+        _initialize(server, root_uri=tmp_path.as_uri())
+        _did_open(server, uri, java_file.read_text())
+        _wait_diagnostics(server)
+
+        _did_save(server, uri)
+        msg = _wait_diagnostics(server)
+        assert msg is not None
+        codes = [d["code"] for d in msg["params"]["diagnostics"]]
+        assert "throw-statement" in codes
+
+
+class TestE2EMultipleRules:
+    def test_multiple_violations(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
+        """A file with multiple violations should report all of them."""
+        java_file = tmp_path / "Multi.java"
+        java_file.write_text(
+            "class T {\n"
+            "  String f() { return null; }\n"
+            "  void g() { throw new RuntimeException(); }\n"
+            "  void h() { for (int i = 0; i < 10; i++) {} }\n"
+            "}"
+        )
+        uri = java_file.as_uri()
+
+        _initialize(server, root_uri=tmp_path.as_uri())
+        _did_open(server, uri, java_file.read_text())
+
+        msg = _wait_diagnostics(server)
+        assert msg is not None
+        codes = {d["code"] for d in msg["params"]["diagnostics"]}
+        assert "null-return" in codes
+        assert "throw-statement" in codes
+        assert "imperative-loop" in codes
+
+    def test_diagnostic_source(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
+        """All diagnostics should have source='java-functional-lsp'."""
+        java_file = tmp_path / "Source.java"
+        java_file.write_text("class T { String f() { return null; } }")
+        uri = java_file.as_uri()
+
+        _initialize(server, root_uri=tmp_path.as_uri())
+        _did_open(server, uri, java_file.read_text())
+
+        msg = _wait_diagnostics(server)
+        assert msg is not None
+        for diag in msg["params"]["diagnostics"]:
+            assert diag["source"] == "java-functional-lsp"
+
+
+class TestE2EDidClose:
+    def test_close_then_reopen(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
+        """Closing a file then reopening should still produce diagnostics."""
+        java_file = tmp_path / "Close.java"
+        java_file.write_text("class T { String f() { return null; } }")
+        uri = java_file.as_uri()
+
+        _initialize(server, root_uri=tmp_path.as_uri())
+        _did_open(server, uri, java_file.read_text())
+        _wait_diagnostics(server)
+
+        _did_close(server, uri)
+
+        # Re-open should still work
+        _did_open(server, uri, java_file.read_text(), version=2)
+        msg = _wait_diagnostics(server)
+        assert msg is not None
+        codes = [d["code"] for d in msg["params"]["diagnostics"]]
+        assert "null-return" in codes
+
+
+class TestE2EConfig:
+    def test_rule_disabled_by_config(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
+        """Rules disabled in .java-functional-lsp.json should not produce diagnostics."""
+        config = tmp_path / ".java-functional-lsp.json"
+        config.write_text('{"rules": {"null-return": "off"}}')
+        java_file = tmp_path / "Config.java"
+        java_file.write_text("class T { String f() { return null; } }")
+        uri = java_file.as_uri()
+
+        _initialize(server, root_uri=tmp_path.as_uri())
+        _did_open(server, uri, java_file.read_text())
+
+        msg = _wait_diagnostics(server)
+        assert msg is not None
+        codes = [d["code"] for d in msg["params"]["diagnostics"]]
+        assert "null-return" not in codes
+
+    def test_excludes_pattern(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
+        """Files matching excludes patterns should produce no diagnostics."""
+        config = tmp_path / ".java-functional-lsp.json"
+        config.write_text('{"excludes": ["**/generated/**"]}')
+        gen_dir = tmp_path / "generated"
+        gen_dir.mkdir()
+        java_file = gen_dir / "Gen.java"
+        java_file.write_text("class T { String f() { return null; } }")
+        uri = java_file.as_uri()
+
+        _initialize(server, root_uri=tmp_path.as_uri())
+        _did_open(server, uri, java_file.read_text())
+
+        msg = _wait_diagnostics(server)
+        assert msg is not None
+        assert len(msg["params"]["diagnostics"]) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -199,6 +199,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
 ]
 
@@ -216,6 +217,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-mock", specifier = ">=3.12.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "ruff", specifier = ">=0.1.0" },
 ]
 
@@ -478,6 +480,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.3.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary

- **11 E2E tests** that start the LSP server as a subprocess over stdio and verify end-to-end behavior
- **Fixed broken incremental parsing** — `tree-sitter parse(src, old_tree)` without `tree.edit()` silently produced incorrect ASTs
- **Fixed thread-safety bug** — `asyncio.to_thread` accessed pygls workspace and parser from background thread, causing stale reads
- **Added `__main__.py`** — enables `python -m java_functional_lsp`

### E2E test coverage

| Test | Verifies |
|------|----------|
| `test_server_capabilities` | Server advertises textDocumentSync |
| `test_server_name` | Server identifies itself |
| `test_diagnostics_on_open` | didOpen triggers diagnostics |
| `test_clean_file_no_diagnostics` | Clean files get empty diagnostics |
| `test_diagnostics_on_change` | didChange + didSave reflects new content |
| `test_diagnostics_on_save` | didSave triggers immediate analysis |
| `test_multiple_violations` | Multiple rules fire on one file |
| `test_diagnostic_source` | All diagnostics have correct source |
| `test_close_then_reopen` | didClose cleanup, reopen works |
| `test_rule_disabled_by_config` | `.java-functional-lsp.json` rules respected |
| `test_excludes_pattern` | Exclude patterns skip analysis |

### Bugs found and fixed

1. **Incremental parsing** (affected `didChange`): `parser.parse(new_src, old_tree)` requires `old_tree.edit()` with exact byte ranges first. Without it, tree-sitter reuses old node boundaries and silently drops changed nodes. Since we use Full document sync (no edit deltas), we now always do a fresh parse.

2. **Thread-safety** (affected `didChange`/`didSave`): `asyncio.to_thread(_publish_diagnostics)` read `server.workspace.get_text_document()` and used `server._parser` from a background thread. Both are not thread-safe. Analysis now runs on the event loop — tree-sitter parses in microseconds, so threading is unnecessary.

## Test plan

- [x] All 109 tests pass (98 existing + 11 new)
- [x] Coverage ≥ 60% (64.88%)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)