### PR TITLE
chore: add git hooks (pre-commit + pre-push)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Pre-commit: run lint, format check, type check, and tests.
+# Bypass with: git commit --no-verify
+
+set -e
+
+echo "Running pre-commit checks..."
+
+echo "  Lint..."
+uv run ruff check src/ tests/
+
+echo "  Format..."
+uv run ruff format --check src/ tests/
+
+echo "  Type check..."
+uv run mypy src/
+
+echo "  Tests..."
+uv run pytest -q
+
+echo "All checks passed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Prevent direct pushes to main/master — all changes must go through PRs.
+
+protected_branches=("main" "master")
+current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+for branch in "${protected_branches[@]}"; do
+    if [ "$current_branch" = "$branch" ]; then
+        echo "ERROR: Direct push to '$branch' is not allowed."
+        echo "Create a feature branch and open a pull request instead."
+        echo ""
+        echo "  git checkout -b feat/my-change"
+        echo "  git push -u origin feat/my-change"
+        echo "  gh pr create"
+        echo ""
+        echo "To bypass (emergency only): git push --no-verify"
+        exit 1
+    fi
+done

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The server speaks the Language Server Protocol (LSP) via stdio, making it compat
 git clone https://github.com/aviadshiber/java-functional-lsp.git
 cd java-functional-lsp
 uv sync
+git config core.hooksPath .githooks
 
 # Run checks
 uv run ruff check src/ tests/
@@ -204,6 +205,10 @@ uv run ruff format --check src/ tests/
 uv run mypy src/
 uv run pytest
 ```
+
+Git hooks in `.githooks/` enforce quality automatically:
+- **pre-commit** — runs lint, format, type check, and tests before each commit
+- **pre-push** — blocks direct pushes to main (use feature branches + PRs)
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines.
 


### PR DESCRIPTION
## Summary

- **pre-commit**: Runs `ruff check`, `ruff format --check`, `mypy`, and `pytest` before each commit
- **pre-push**: Blocks direct pushes to main/master with helpful error message
- Documents `git config core.hooksPath .githooks` in README Development section

Contributors activate hooks with `git config core.hooksPath .githooks` after cloning.
Bypass with `--no-verify` for emergencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)