### PR TITLE
fix: remove getOrNull from diagnostic message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.6.1"
+version = "0.6.2"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/src/java_functional_lsp/analyzers/functional_checker.py
+++ b/src/java_functional_lsp/analyzers/functional_checker.py
@@ -21,7 +21,7 @@ _MESSAGES = {
         "Runtime Exception Risk: Mutating a frozen structure (e.g. List.of()). "
         "Use io.vavr.collection.List for safe persistent immutability."
     ),
-    "null-check-to-monadic": ("Imperative null handling: Consider monadic flow with Option.of().map().getOrNull()."),
+    "null-check-to-monadic": ("Imperative null handling: Consider monadic flow with Option.of().map().getOrElse()."),
     "impure-method": (
         "Hidden side-effect: Method mixes pure logic with IO/state mutations. "
         "Extract pure logic to a separate method; wrap side-effects in Try."


### PR DESCRIPTION
## Summary
- Update null-check-to-monadic diagnostic message from `.getOrNull()` to `.getOrElse()`
- The old message contradicted our own null-safety rules
- Bump version to 0.6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)