### PR TITLE
feat: chained null-check code action with Option.orElse() chains

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.6.2"
+version = "0.6.3"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }
@@ -79,6 +79,7 @@ ignore = ["PLR0913", "PLC0415", "PLW0603", "PLW0602"]
 "__init__.py" = ["E402"]
 "**/test_*.py" = ["PLR2004"]
 "**/cli.py" = ["T20", "PLR0912", "PLR2004"]
+"**/fixes.py" = ["PLR0911", "PLR0912"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/src/java_functional_lsp/analyzers/functional_checker.py
+++ b/src/java_functional_lsp/analyzers/functional_checker.py
@@ -235,6 +235,19 @@ class FunctionalChecker:
             if not self._references_var(stmt, checked_var):
                 continue
 
+            # Suppress inner if_nodes that are part of an outer chained null-check.
+            # Walk: if_node → parent block → check if that block is the "alternative"
+            # of an outer if_statement that null-checks the same variable.
+            parent_block = if_node.parent
+            if parent_block is not None and parent_block.type == "block":
+                outer_if = parent_block.parent
+                if outer_if is not None and outer_if.type == "if_statement":
+                    alt_node = outer_if.child_by_field_name("alternative")
+                    if alt_node is not None and alt_node == parent_block:
+                        outer_condition = outer_if.child_by_field_name("condition")
+                        if outer_condition is not None and extract_null_check_var(outer_condition) == checked_var:
+                            continue  # outer if already carries the diagnostic
+
             diagnostics.append(
                 Diagnostic(
                     line=if_node.start_point[0],

--- a/src/java_functional_lsp/fixes.py
+++ b/src/java_functional_lsp/fixes.py
@@ -5,6 +5,7 @@ Each fix generator takes document context and returns a list of TextEdits.
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Callable
 from typing import Any
@@ -13,6 +14,11 @@ from lsprotocol import types as lsp
 from tree_sitter import Node, Tree
 
 from .analyzers.base import extract_null_check_var, find_ancestor, find_nodes, get_parser
+
+logger = logging.getLogger(__name__)
+
+_MAX_CHAIN_DEPTH = 10
+_COMPLEX_EXPR_TYPES: frozenset[str] = frozenset({"ternary_expression", "lambda_expression", "assignment_expression"})
 
 # Type for fix generator functions: (uri, source, diag_range, config, *, tree, lines) -> WorkspaceEdit | None
 FixGenerator = Callable[..., lsp.WorkspaceEdit | None]
@@ -309,6 +315,185 @@ def _else_terminal(alternative: Node) -> str | None:
     return f".getOrElse(() -> {val_text})"
 
 
+def _safe_expr_text(node: Node) -> str:
+    """Extract expression text, parenthesizing complex expressions to avoid syntax issues."""
+    text = node.text.decode("utf-8") if node.text else ""
+    if node.type in _COMPLEX_EXPR_TYPES:
+        return f"({text})"
+    return text
+
+
+def _is_identity_return(consequence: Node | None, var_name: str) -> bool:
+    """Return True if consequence block has exactly one return_statement returning var_name."""
+    if consequence is None:
+        return False
+    stmts = [c for c in consequence.named_children if c.type not in ("line_comment", "block_comment")]
+    if len(stmts) != 1 or stmts[0].type != "return_statement":
+        return False
+    expr_children = list(stmts[0].named_children)
+    if not expr_children:
+        return False
+    ret_node = expr_children[0]
+    return ret_node.type == "identifier" and ret_node.text == var_name.encode("utf-8")
+
+
+def _collect_chained_fallbacks(alternative: Node, var_name: str) -> list[str] | None:
+    """Collect fallback expressions from chained identity null-checks.
+
+    Iteratively walks nested else blocks. Each level must have exactly:
+    1. expression_statement with assignment_expression (left == var_name)
+    2. if_statement with null-check on var_name and identity return
+
+    Returns list of fallback expression texts, or None if pattern doesn't match.
+    """
+    fallbacks: list[str] = []
+    current_alt = alternative
+    var_bytes = var_name.encode("utf-8")
+
+    for _ in range(_MAX_CHAIN_DEPTH):
+        stmts = [c for c in current_alt.named_children if c.type not in ("line_comment", "block_comment")]
+        if len(stmts) != 2:  # noqa: PLR2004
+            return None
+
+        assign_stmt, nested_if = stmts[0], stmts[1]
+
+        # Validate assignment statement
+        if assign_stmt.type != "expression_statement":
+            return None
+        assign = next(
+            (c for c in assign_stmt.named_children if c.type == "assignment_expression"),
+            None,
+        )
+        if assign is None:
+            return None
+        left = assign.child_by_field_name("left")
+        right = assign.child_by_field_name("right")
+        if left is None or right is None or left.text != var_bytes:
+            return None
+
+        # Validate nested if_statement
+        if nested_if.type != "if_statement":
+            return None
+        condition = nested_if.child_by_field_name("condition")
+        if condition is None or extract_null_check_var(condition) != var_bytes:
+            return None
+
+        # Check identity return in consequence
+        consequence = nested_if.child_by_field_name("consequence")
+        if not _is_identity_return(consequence, var_name):
+            return None
+
+        # Extract fallback expression text, parenthesize if complex
+        fallback_text = _safe_expr_text(right)
+        fallbacks.append(fallback_text)
+
+        # Continue to next level if there is a nested alternative
+        next_alt = nested_if.child_by_field_name("alternative")
+        if next_alt is None:
+            return fallbacks
+        current_alt = next_alt
+
+    return None  # exceeded max depth
+
+
+def _try_chained_null_rewrite(if_node: Node, var_name: str) -> lsp.TextEdit | None:
+    """Attempt to rewrite a chained identity null-check pattern to Option.of().orElse().getOrElse().
+
+    The pattern is:
+        T var = expr1;
+        if (var != null) { return var; }
+        else {
+            var = expr2;
+            if (var != null) { return var; }
+            [else { var = expr3; if (var != null) { return var; } }]
+        }
+        return default;
+
+    Returns a TextEdit replacing the variable declaration through the final return, or None.
+    """
+    # 1. Verify consequence is identity return
+    consequence = if_node.child_by_field_name("consequence")
+    if not _is_identity_return(consequence, var_name):
+        return None
+
+    # 2. Require an else branch
+    alternative = if_node.child_by_field_name("alternative")
+    if alternative is None:
+        return None
+
+    # 3. prev_named_sibling must be local_variable_declaration containing var_name
+    prev_sib = if_node.prev_named_sibling
+    if prev_sib is None or prev_sib.type != "local_variable_declaration":
+        return None
+
+    # Extract initializer from the declarator
+    var_bytes = var_name.encode("utf-8")
+    initial_expr: str | None = None
+    for declarator in prev_sib.children:
+        if declarator.type != "variable_declarator":
+            continue
+        name_node = declarator.child_by_field_name("name")
+        if name_node is None or name_node.text != var_bytes:
+            continue
+        value_node = declarator.child_by_field_name("value")
+        if value_node is None:
+            return None
+        initial_expr = _safe_expr_text(value_node)
+        break
+
+    if initial_expr is None:
+        return None
+
+    # 4. Collect chained fallbacks from the else branch
+    fallbacks = _collect_chained_fallbacks(alternative, var_name)
+    if fallbacks is None:
+        return None
+
+    # 5. next_named_sibling must be return_statement with non-null value
+    next_sib = if_node.next_named_sibling
+    if next_sib is None or next_sib.type != "return_statement":
+        return None
+
+    ret_children = list(next_sib.named_children)
+    if not ret_children:
+        return None
+
+    default_node = ret_children[0]
+    # Null default → changing return type is unsafe, no code action
+    if default_node.type == "null_literal":
+        return None
+
+    default_text = default_node.text.decode("utf-8") if default_node.text else ""
+    if _is_eager(default_node):
+        terminal = f".getOrElse({default_text})"
+    else:
+        terminal = f".getOrElse(() -> {default_text})"
+
+    # 6. Build replacement text
+    indent = " " * prev_sib.start_point[1]
+    align = " " * len("return ")
+    lines_out: list[str] = [f"return Option.of({initial_expr})"]
+    for fb in fallbacks:
+        lines_out.append(f"{indent}{align}.orElse(() -> Option.of({fb}))")
+    lines_out[-1] += terminal + ";"
+
+    # Join all but the last with newline (last has the semicolon already)
+    new_text = "\n".join(lines_out)
+
+    # 7. Replace range from variable declaration start through final return end
+    replace_start = lsp.Position(line=prev_sib.start_point[0], character=prev_sib.start_point[1])
+    replace_end = lsp.Position(line=next_sib.end_point[0], character=next_sib.end_point[1])
+
+    logger.debug(
+        "Chained null-check rewrite: %d fallbacks, lines %d-%d",
+        len(fallbacks),
+        prev_sib.start_point[0],
+        next_sib.end_point[0],
+    )
+
+    return lsp.TextEdit(range=lsp.Range(start=replace_start, end=replace_end), new_text=new_text)
+
+
 def _build_monadic_rewrite(if_node: Node, var_name: str) -> lsp.TextEdit | None:
     """Build the Option.of().map() replacement TextEdit for a null-check if-block.
 
@@ -354,9 +539,15 @@ def _build_monadic_rewrite(if_node: Node, var_name: str) -> lsp.TextEdit | None:
         terminal = ""  # bare Option — no .getOrNull()
     else:
         else_result = _else_terminal(alternative)
-        if else_result is None:
-            return None  # complex else
-        terminal = else_result
+        if else_result is not None:
+            terminal = else_result
+        else:
+            # Try chained identity null-check pattern
+            if is_identity:
+                chained = _try_chained_null_rewrite(if_node, var_name)
+                if chained is not None:
+                    return chained
+            return None  # complex else, diagnostic only
 
     # --- Assemble new_text ---
     base = f"Option.of({var_name})"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -513,6 +513,54 @@ class TestE2ECodeAction:
         assert "edit" in action
         assert action["title"] == "Convert to Option monadic flow"
 
+    def test_chained_null_check_code_action(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
+        """E2E: chained null-check should produce code action with orElse chain."""
+        java_file = tmp_path / "Chained.java"
+        java_file.write_text(
+            "class T {\n"
+            "    int f(String key) {\n"
+            "        Integer val = map.get(key);\n"
+            "        if (val != null) {\n"
+            "            return val;\n"
+            "        } else {\n"
+            "            val = fallback.get(key);\n"
+            "            if (val != null) {\n"
+            "                return val;\n"
+            "            }\n"
+            "        }\n"
+            "        return defaultVal;\n"
+            "    }\n"
+            "}\n"
+        )
+        uri = java_file.as_uri()
+
+        _initialize(server, root_uri=tmp_path.as_uri())
+        _did_open(server, uri, java_file.read_text())
+
+        msg = _wait_diagnostics(server)
+        assert msg is not None
+        monadic_diags = [d for d in msg["params"]["diagnostics"] if d["code"] == "null-check-to-monadic"]
+        assert len(monadic_diags) >= 1
+
+        response = _request_code_actions(server, uri, monadic_diags[0]["range"], monadic_diags)
+        assert response is not None
+        result = response.get("result")
+        assert result is not None
+        assert len(result) >= 1
+
+        # Find the quickfix action
+        quickfix_actions = [a for a in result if a.get("kind") == "quickfix"]
+        assert len(quickfix_actions) >= 1
+        action = quickfix_actions[0]
+        assert "edit" in action
+
+        # Verify the edit contains an orElse chain
+        changes = action["edit"].get("changes", {})
+        all_new_text = " ".join(e["newText"] for edits in changes.values() for e in edits if "newText" in e)
+        assert "Option.of(" in all_new_text
+        assert ".orElse(" in all_new_text
+        assert ".getOrElse(" in all_new_text
+
     def test_code_action_unknown_source_returns_none(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
         """Code action request with diagnostics from a non-java-functional-lsp source should return null."""
         java_file = tmp_path / "Other.java"

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -401,6 +401,227 @@ class TestFixNullCheckToMonadic:
         assert ".map(" not in rewrite[0].new_text
         assert ".getOrElse(defaultVal)" in rewrite[0].new_text
 
+    def test_chained_two_level_identity(self) -> None:
+        """Two-level chain -> Option.of().orElse().getOrElse()."""
+        source = (
+            "class T {\n"
+            "    int f(String key) {\n"
+            "        Integer val = map.get(key);\n"
+            "        if (val != null) {\n"
+            "            return val;\n"
+            "        } else {\n"
+            "            val = fallback.get(key);\n"
+            "            if (val != null) {\n"
+            "                return val;\n"
+            "            }\n"
+            "        }\n"
+            "        return defaultVal;\n"
+            "    }\n"
+            "}"
+        )
+        result = fix_null_check_to_monadic("file:///test.java", source, _range(3, 8, 10, 9), {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = [e for e in edits if "Option.of(" in e.new_text]
+        assert len(rewrite) == 1
+        text = rewrite[0].new_text
+        assert "Option.of(map.get(key))" in text
+        assert ".orElse(() -> Option.of(fallback.get(key)))" in text
+        assert ".getOrElse(defaultVal)" in text
+
+    def test_chained_three_level_identity(self) -> None:
+        """Three-level chain -> two .orElse() calls."""
+        source = (
+            "class T {\n"
+            "    int f(String key) {\n"
+            "        Integer val = m1.get(key);\n"
+            "        if (val != null) {\n"
+            "            return val;\n"
+            "        } else {\n"
+            "            val = m2.get(key);\n"
+            "            if (val != null) {\n"
+            "                return val;\n"
+            "            } else {\n"
+            "                val = m3.get(key);\n"
+            "                if (val != null) {\n"
+            "                    return val;\n"
+            "                }\n"
+            "            }\n"
+            "        }\n"
+            "        return defaultVal;\n"
+            "    }\n"
+            "}"
+        )
+        result = fix_null_check_to_monadic("file:///test.java", source, _range(3, 8, 15, 9), {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = [e for e in edits if "Option.of(" in e.new_text]
+        assert len(rewrite) == 1
+        text = rewrite[0].new_text
+        assert text.count(".orElse(") == 2
+
+    def test_chained_lazy_default(self) -> None:
+        """Method call default -> .getOrElse(() -> compute())."""
+        source = (
+            "class T {\n"
+            "    int f(String key) {\n"
+            "        Integer val = map.get(key);\n"
+            "        if (val != null) {\n"
+            "            return val;\n"
+            "        } else {\n"
+            "            val = fallback.get(key);\n"
+            "            if (val != null) {\n"
+            "                return val;\n"
+            "            }\n"
+            "        }\n"
+            "        return computeDefault();\n"
+            "    }\n"
+            "}"
+        )
+        result = fix_null_check_to_monadic("file:///test.java", source, _range(3, 8, 10, 9), {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = [e for e in edits if "Option.of(" in e.new_text]
+        assert len(rewrite) == 1
+        assert ".getOrElse(() -> computeDefault())" in rewrite[0].new_text
+
+    def test_chained_null_default_returns_none(self) -> None:
+        """Null default -> no code action (return type change unsafe)."""
+        source = (
+            "class T {\n"
+            "    Integer f(String key) {\n"
+            "        Integer val = map.get(key);\n"
+            "        if (val != null) {\n"
+            "            return val;\n"
+            "        } else {\n"
+            "            val = fallback.get(key);\n"
+            "            if (val != null) {\n"
+            "                return val;\n"
+            "            }\n"
+            "        }\n"
+            "        return null;\n"
+            "    }\n"
+            "}"
+        )
+        result = fix_null_check_to_monadic("file:///test.java", source, _range(3, 8, 10, 9), {})
+        assert result is None
+
+    def test_chained_non_identity_returns_none(self) -> None:
+        """Non-identity return in chain -> no code action."""
+        source = (
+            "class T {\n"
+            "    String f(String key) {\n"
+            "        String val = map.get(key);\n"
+            "        if (val != null) {\n"
+            "            return val.trim();\n"
+            "        } else {\n"
+            "            val = fallback.get(key);\n"
+            "            if (val != null) {\n"
+            "                return val;\n"
+            "            }\n"
+            "        }\n"
+            "        return defaultVal;\n"
+            "    }\n"
+            "}"
+        )
+        result = fix_null_check_to_monadic("file:///test.java", source, _range(3, 8, 10, 9), {})
+        assert result is None
+
+    def test_chained_extra_statements_returns_none(self) -> None:
+        """Side effects in else -> no code action."""
+        source = (
+            "class T {\n"
+            "    int f(String key) {\n"
+            "        Integer val = map.get(key);\n"
+            "        if (val != null) {\n"
+            "            return val;\n"
+            "        } else {\n"
+            "            logger.debug(key);\n"
+            "            val = fallback.get(key);\n"
+            "            if (val != null) {\n"
+            "                return val;\n"
+            "            }\n"
+            "        }\n"
+            "        return defaultVal;\n"
+            "    }\n"
+            "}"
+        )
+        result = fix_null_check_to_monadic("file:///test.java", source, _range(3, 8, 11, 9), {})
+        assert result is None
+
+    def test_chained_no_default_return_returns_none(self) -> None:
+        """No return after if/else -> no code action."""
+        source = (
+            "class T {\n"
+            "    void f(String key) {\n"
+            "        Integer val = map.get(key);\n"
+            "        if (val != null) {\n"
+            "            return val;\n"
+            "        } else {\n"
+            "            val = fallback.get(key);\n"
+            "            if (val != null) {\n"
+            "                return val;\n"
+            "            }\n"
+            "        }\n"
+            "        doSomething();\n"
+            "    }\n"
+            "}"
+        )
+        result = fix_null_check_to_monadic("file:///test.java", source, _range(3, 8, 10, 9), {})
+        assert result is None
+
+    def test_chained_declaration_not_adjacent_returns_none(self) -> None:
+        """Declaration separated from if by other statements -> no code action."""
+        source = (
+            "class T {\n"
+            "    int f(String key) {\n"
+            "        Integer val = map.get(key);\n"
+            "        log(val);\n"
+            "        if (val != null) {\n"
+            "            return val;\n"
+            "        } else {\n"
+            "            val = fallback.get(key);\n"
+            "            if (val != null) {\n"
+            "                return val;\n"
+            "            }\n"
+            "        }\n"
+            "        return defaultVal;\n"
+            "    }\n"
+            "}"
+        )
+        result = fix_null_check_to_monadic("file:///test.java", source, _range(4, 8, 11, 9), {})
+        assert result is None
+
+    def test_chained_complex_fallback_parenthesized(self) -> None:
+        """Ternary in fallback expression -> parenthesized in output."""
+        source = (
+            "class T {\n"
+            "    int f(String key) {\n"
+            "        Integer val = map.get(key);\n"
+            "        if (val != null) {\n"
+            "            return val;\n"
+            "        } else {\n"
+            "            val = useBackup ? backup.get(key) : other.get(key);\n"
+            "            if (val != null) {\n"
+            "                return val;\n"
+            "            }\n"
+            "        }\n"
+            "        return defaultVal;\n"
+            "    }\n"
+            "}"
+        )
+        result = fix_null_check_to_monadic("file:///test.java", source, _range(3, 8, 10, 9), {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = [e for e in edits if "Option.of(" in e.new_text]
+        assert len(rewrite) == 1
+        # Ternary should be parenthesized
+        assert "(useBackup ? backup.get(key) : other.get(key))" in rewrite[0].new_text
+
 
 class TestFixNullReturn:
     def test_replaces_null_with_option_none(self) -> None:

--- a/tests/test_functional_checker.py
+++ b/tests/test_functional_checker.py
@@ -349,6 +349,29 @@ class TestNullCheckToMonadic:
         diags = parse_and_analyze(FunctionalChecker(), source)
         assert any(d.code == "null-check-to-monadic" for d in diags)
 
+    def test_inner_chained_if_suppressed(self) -> None:
+        """Inner if in a chain should NOT produce a separate diagnostic."""
+        source = b"""
+    class T {
+        int f(String key) {
+            Integer val = map.get(key);
+            if (val != null) {
+                return val;
+            } else {
+                val = fallback.get(key);
+                if (val != null) {
+                    return val;
+                }
+            }
+            return defaultVal;
+        }
+    }
+    """
+        diags = parse_and_analyze(FunctionalChecker(), source)
+        null_check_diags = [d for d in diags if d.code == "null-check-to-monadic"]
+        # Should be exactly 1 (outer if), not 2
+        assert len(null_check_diags) == 1
+
 
 class TestImpureMethod:
     def test_detects_mixed_method(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.6.0"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary

Detect and rewrite chained identity null-checks into `Option.of().orElse().getOrElse()` chains.

```java
// BEFORE
Integer val = map1.get(key);
if (val != null) {
    return val;
} else {
    val = map2.get(key);
    if (val != null) { return val; }
}
return defaultVal;

// AFTER (code action)
return Option.of(map1.get(key))
             .orElse(() -> Option.of(map2.get(key)))
             .getOrElse(defaultVal);
```

## Design decisions (from 4-agent design ensemble review)

| Decision | Rationale |
|----------|-----------|
| Identity returns only | Non-identity too complex for safe auto-rewrite |
| Iterative collection, max 10 depth | Avoids stack overflow on pathological ASTs |
| Declaration must be immediate prev sibling | Prevents silently deleting intervening code |
| Parenthesize complex fallbacks | Ternary/lambda in `() -> Option.of(expr)` needs parens |
| Null default → diagnostic only | Changing return type contract is unsafe |
| Lazy `.getOrElse(() -> ...)` for method calls | Preserves evaluation semantics |
| Suppress inner chain diagnostics | Prevents duplicate/conflicting code actions |

## Test plan

- [x] 216 tests pass (11 new)
- [x] 75% coverage
- [x] ruff, pyright, mypy clean
- [x] E2E test for full LSP round-trip
- [ ] Manual test in IntelliJ on `TaxonomyDiversityRBlockerQuery.java`

🤖 Generated with [Claude Code](https://claude.com/claude-code)