### PR TITLE
feat: add try-catch-to-monadic code action with Vavr Try.of() rewrites

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.6.6"
+version = "0.6.7"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.6.5"
+version = "0.6.6"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.6.6"
+__version__ = "0.6.7"

--- a/src/java_functional_lsp/analyzers/base.py
+++ b/src/java_functional_lsp/analyzers/base.py
@@ -49,6 +49,10 @@ class Analyzer(Protocol):
         ...
 
 
+#: Tree-sitter child node types that should be skipped when iterating named_children.
+#: Shared across analyzers and fix generators so comment-filtering stays consistent.
+IGNORED_CHILDREN = ("line_comment", "block_comment")
+
 _parser: Parser | None = None
 _language: Language | None = None
 
@@ -141,6 +145,54 @@ def has_ancestor(node: Node, type_names: set[str]) -> bool:
         if parent.type in type_names:
             return True
         parent = parent.parent
+    return False
+
+
+def references_var(node: Node, var_name: bytes) -> bool:
+    """Return True if any identifier descendant of ``node`` has text equal to ``var_name``.
+
+    Used to detect whether an expression references a given variable (e.g. an
+    exception variable inside a catch-return expression). Uses a TreeCursor walk
+    for performance — no recursion, no allocation per node.
+    """
+    cursor = node.walk()
+    visited_children = False
+    while True:
+        if not visited_children:
+            cur = cursor.node
+            if cur is not None and cur.type == "identifier" and cur.text == var_name:
+                return True
+            if not cursor.goto_first_child():
+                visited_children = True
+        elif cursor.goto_next_sibling():
+            visited_children = False
+        elif not cursor.goto_parent():
+            break
+    return False
+
+
+def has_error_or_missing(node: Node) -> bool:
+    """Return True if the subtree rooted at ``node`` contains any ERROR or MISSING nodes.
+
+    Used by fix generators as a defensive gate: tree-sitter's error recovery
+    produces partial trees for malformed input (common during incremental typing
+    in editors), and emitting a rewrite from such input can produce invalid edits.
+    """
+    if node.has_error or node.is_missing:
+        return True
+    cursor = node.walk()
+    visited_children = False
+    while True:
+        if not visited_children:
+            cur = cursor.node
+            if cur is not None and (cur.type == "ERROR" or cur.is_missing):
+                return True
+            if not cursor.goto_first_child():
+                visited_children = True
+        elif cursor.goto_next_sibling():
+            visited_children = False
+        elif not cursor.goto_parent():
+            break
     return False
 
 

--- a/src/java_functional_lsp/analyzers/exception_checker.py
+++ b/src/java_functional_lsp/analyzers/exception_checker.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import Diagnostic, DiagnosticData, find_nodes, has_sibling_annotation, severity_from_config
+from .base import Diagnostic, DiagnosticData, Severity, find_nodes, has_sibling_annotation, severity_from_config
+
+_IGNORED_CHILDREN = ("line_comment", "block_comment")
 
 _MESSAGES = {
     "throw-statement": ("Avoid throwing exceptions. Use Either.left(error) or Try.of(() -> ...).toEither()."),
     "catch-rethrow": (
         "Avoid catching and rethrowing. Use Try.of(() -> ...).toEither() to convert exceptions to values."
     ),
+    "try-catch-to-monadic": ("Imperative try/catch: use Try.of(() -> ...) for monadic error handling."),
 }
 
 _DATA = {
@@ -29,6 +32,14 @@ _DATA = {
             "Catching and rethrowing adds noise. Use Try.of(() -> ...).toEither() to convert exceptions to values."
         ),
     ),
+    "try-catch-to-monadic": DiagnosticData(
+        fix_type="WRAP_IN_TRY",
+        target_library="io.vavr.control.Try",
+        rationale=(
+            "try/catch mixes control flow with value handling."
+            " Use Try.of(...) for composable, value-based failure handling."
+        ),
+    ),
 }
 
 
@@ -43,6 +54,57 @@ def _is_in_bean_method(node: Any) -> bool:
             return False
         parent = parent.parent
     return False
+
+
+def _matches_try_catch_monadic_shape(try_node: Any) -> bool:  # noqa: PLR0911
+    """Verify a try_statement has a shape the code action can rewrite.
+
+    Requirements:
+    - No ``finally_clause`` child
+    - Exactly one ``catch_clause`` child
+    - Try body is a block with a single ``return_statement`` that has an expression
+    - Catch body is a block whose last named child is a ``return_statement``,
+      and any prior named children are ``expression_statement`` (for the logging pattern)
+
+    Guard-clause returns are preferred for readability; noqa silences the
+    "too many returns" rule since each branch fails a distinct shape check.
+    """
+    # Reject if finally present
+    if any(c.type == "finally_clause" for c in try_node.children):
+        return False
+
+    # Exactly one catch clause
+    catches = [c for c in try_node.children if c.type == "catch_clause"]
+    if len(catches) != 1:
+        return False
+
+    # Try body must be a block with a single return_statement with an expression
+    body = try_node.child_by_field_name("body")
+    if body is None or body.type != "block":
+        return False
+    body_stmts = [c for c in body.named_children if c.type not in _IGNORED_CHILDREN]
+    if len(body_stmts) != 1 or body_stmts[0].type != "return_statement":
+        return False
+    # Return must have an expression (not bare `return;`)
+    ret_children = [c for c in body_stmts[0].named_children if c.type not in _IGNORED_CHILDREN]
+    if not ret_children:
+        return False
+
+    # Catch body must end with a return_statement; prior stmts must be expression_statements
+    catch_body = catches[0].child_by_field_name("body")
+    if catch_body is None or catch_body.type != "block":
+        return False
+    catch_stmts = [c for c in catch_body.named_children if c.type not in _IGNORED_CHILDREN]
+    if not catch_stmts or catch_stmts[-1].type != "return_statement":
+        return False
+    if any(s.type != "expression_statement" for s in catch_stmts[:-1]):
+        return False
+    # The catch return must have an expression
+    catch_ret_children = [c for c in catch_stmts[-1].named_children if c.type not in _IGNORED_CHILDREN]
+    if not catch_ret_children:
+        return False
+
+    return True
 
 
 class ExceptionChecker:
@@ -79,7 +141,7 @@ class ExceptionChecker:
                 body = node.child_by_field_name("body")
                 if body is None:
                     continue
-                statements = [c for c in body.named_children if c.type not in ("line_comment", "block_comment")]
+                statements = [c for c in body.named_children if c.type not in _IGNORED_CHILDREN]
                 if len(statements) == 1 and statements[0].type == "throw_statement":
                     diagnostics.append(
                         Diagnostic(
@@ -93,5 +155,28 @@ class ExceptionChecker:
                             data=_DATA["catch-rethrow"],
                         )
                     )
+
+        # Rule: try-catch-to-monadic
+        severity = severity_from_config(config, "try-catch-to-monadic", default=Severity.HINT)
+        if severity is not None:
+            for try_node in find_nodes(tree.root_node, "try_statement"):
+                if _is_in_bean_method(try_node):
+                    continue
+                if not _matches_try_catch_monadic_shape(try_node):
+                    continue
+                # Position the diagnostic on the `try` keyword only (narrow range).
+                try_kw = next((c for c in try_node.children if c.type == "try"), try_node)
+                diagnostics.append(
+                    Diagnostic(
+                        line=try_kw.start_point[0],
+                        col=try_kw.start_point[1],
+                        end_line=try_kw.end_point[0],
+                        end_col=try_kw.end_point[1],
+                        severity=severity,
+                        code="try-catch-to-monadic",
+                        message=_MESSAGES["try-catch-to-monadic"],
+                        data=_DATA["try-catch-to-monadic"],
+                    )
+                )
 
         return diagnostics

--- a/src/java_functional_lsp/analyzers/exception_checker.py
+++ b/src/java_functional_lsp/analyzers/exception_checker.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from .base import Diagnostic, DiagnosticData, Severity, find_nodes, has_sibling_annotation, severity_from_config
-
-_IGNORED_CHILDREN = ("line_comment", "block_comment")
+from .base import (
+    IGNORED_CHILDREN,
+    Diagnostic,
+    DiagnosticData,
+    Severity,
+    collect_nodes_by_type,
+    has_sibling_annotation,
+    severity_from_config,
+)
 
 _MESSAGES = {
     "throw-statement": ("Avoid throwing exceptions. Use Either.left(error) or Try.of(() -> ...).toEither()."),
@@ -56,51 +62,76 @@ def _is_in_bean_method(node: Any) -> bool:
     return False
 
 
-def _matches_try_catch_monadic_shape(try_node: Any) -> bool:  # noqa: PLR0911
-    """Verify a try_statement has a shape the code action can rewrite.
+def _matches_try_catch_monadic_shape(try_node: Any) -> bool:  # noqa: PLR0911, PLR0912
+    """Verify a try_statement has a shape the try-catch-to-monadic fix can rewrite.
 
     Requirements:
+    - No ``resource_specification`` child (try-with-resources would lose auto-close semantics)
     - No ``finally_clause`` child
     - Exactly one ``catch_clause`` child
+    - Catch clause must use a single exception type (no union-catch ``A | B e``)
     - Try body is a block with a single ``return_statement`` that has an expression
-    - Catch body is a block whose last named child is a ``return_statement``,
-      and any prior named children are ``expression_statement`` (for the logging pattern)
+    - Catch body is a block whose last named child is a ``return_statement`` with an expression,
+      and any prior named children are ``expression_statement`` (for the Pattern 2 logging case)
 
     Guard-clause returns are preferred for readability; noqa silences the
     "too many returns" rule since each branch fails a distinct shape check.
+
+    Note: This analyzer-side check must stay in sync with
+    ``_validate_and_extract_try_catch_parts`` in fixes.py — any shape the
+    analyzer accepts must also be rewritable by the fix, otherwise users
+    see a diagnostic with no working code action.
     """
-    # Reject if finally present
-    if any(c.type == "finally_clause" for c in try_node.children):
+    # Single pass over try_node.children: detect finally, resource_specification, and catches
+    has_finally = False
+    has_resources = False
+    catches: list[Any] = []
+    for c in try_node.children:
+        if c.type == "finally_clause":
+            has_finally = True
+        elif c.type == "resource_specification":
+            has_resources = True
+        elif c.type == "catch_clause":
+            catches.append(c)
+
+    if has_finally or has_resources:
+        return False
+    if len(catches) != 1:
         return False
 
-    # Exactly one catch clause
-    catches = [c for c in try_node.children if c.type == "catch_clause"]
-    if len(catches) != 1:
+    # Reject union-catch (A | B e). Tree-sitter encodes the type in catch_formal_parameter
+    # as either a single type node or a catch_type node containing multiple type_identifier children.
+    catch = catches[0]
+    param = next((c for c in catch.children if c.type == "catch_formal_parameter"), None)
+    if param is None:
+        return False
+    catch_type_node = next((c for c in param.children if c.type == "catch_type"), None)
+    if catch_type_node is not None and catch_type_node.text and b"|" in catch_type_node.text:
         return False
 
     # Try body must be a block with a single return_statement with an expression
     body = try_node.child_by_field_name("body")
     if body is None or body.type != "block":
         return False
-    body_stmts = [c for c in body.named_children if c.type not in _IGNORED_CHILDREN]
+    body_stmts = [c for c in body.named_children if c.type not in IGNORED_CHILDREN]
     if len(body_stmts) != 1 or body_stmts[0].type != "return_statement":
         return False
     # Return must have an expression (not bare `return;`)
-    ret_children = [c for c in body_stmts[0].named_children if c.type not in _IGNORED_CHILDREN]
+    ret_children = [c for c in body_stmts[0].named_children if c.type not in IGNORED_CHILDREN]
     if not ret_children:
         return False
 
     # Catch body must end with a return_statement; prior stmts must be expression_statements
-    catch_body = catches[0].child_by_field_name("body")
+    catch_body = catch.child_by_field_name("body")
     if catch_body is None or catch_body.type != "block":
         return False
-    catch_stmts = [c for c in catch_body.named_children if c.type not in _IGNORED_CHILDREN]
+    catch_stmts = [c for c in catch_body.named_children if c.type not in IGNORED_CHILDREN]
     if not catch_stmts or catch_stmts[-1].type != "return_statement":
         return False
     if any(s.type != "expression_statement" for s in catch_stmts[:-1]):
         return False
-    # The catch return must have an expression
-    catch_ret_children = [c for c in catch_stmts[-1].named_children if c.type not in _IGNORED_CHILDREN]
+    # The catch return must have an expression (not bare `return;`)
+    catch_ret_children = [c for c in catch_stmts[-1].named_children if c.type not in IGNORED_CHILDREN]
     if not catch_ret_children:
         return False
 
@@ -113,10 +144,15 @@ class ExceptionChecker:
     def analyze(self, tree: Any, source: bytes, config: dict[str, Any]) -> list[Diagnostic]:
         diagnostics: list[Diagnostic] = []
 
+        # Single tree walk collecting all three node types we care about.
+        # Previously this method did three separate find_nodes walks, which is 3x the traversal
+        # cost on every analysis pass (LSP re-runs on every document change).
+        buckets = collect_nodes_by_type(tree.root_node, {"throw_statement", "catch_clause", "try_statement"})
+
         # Rule: throw-statement
         severity = severity_from_config(config, "throw-statement")
         if severity is not None:
-            for node in find_nodes(tree.root_node, "throw_statement"):
+            for node in buckets["throw_statement"]:
                 if _is_in_bean_method(node):
                     continue
                 diagnostics.append(
@@ -135,13 +171,13 @@ class ExceptionChecker:
         # Rule: catch-rethrow
         severity = severity_from_config(config, "catch-rethrow")
         if severity is not None:
-            for node in find_nodes(tree.root_node, "catch_clause"):
+            for node in buckets["catch_clause"]:
                 if _is_in_bean_method(node):
                     continue
                 body = node.child_by_field_name("body")
                 if body is None:
                     continue
-                statements = [c for c in body.named_children if c.type not in _IGNORED_CHILDREN]
+                statements = [c for c in body.named_children if c.type not in IGNORED_CHILDREN]
                 if len(statements) == 1 and statements[0].type == "throw_statement":
                     diagnostics.append(
                         Diagnostic(
@@ -159,7 +195,7 @@ class ExceptionChecker:
         # Rule: try-catch-to-monadic
         severity = severity_from_config(config, "try-catch-to-monadic", default=Severity.HINT)
         if severity is not None:
-            for try_node in find_nodes(tree.root_node, "try_statement"):
+            for try_node in buckets["try_statement"]:
                 if _is_in_bean_method(try_node):
                     continue
                 if not _matches_try_catch_monadic_shape(try_node):

--- a/src/java_functional_lsp/analyzers/functional_checker.py
+++ b/src/java_functional_lsp/analyzers/functional_checker.py
@@ -130,6 +130,37 @@ _SIDE_EFFECT_METHODS = {
 _METHOD_SCOPES = {"method_declaration", "constructor_declaration", "lambda_expression"}
 
 
+def is_side_effect_invocation(invocation: Node) -> bool:
+    """Check if a method_invocation node is a side-effect call.
+
+    Recognizes patterns like:
+    - ``System.out.println(...)`` / ``System.err.println(...)``
+    - ``logger.info(...)`` / ``log.debug(...)`` / ``LOG.warn(...)``
+    - Bare side-effect method names (e.g. ``println(...)``)
+    """
+    obj_node = invocation.child_by_field_name("object")
+    method_name = invocation.child_by_field_name("name")
+    if method_name is None:
+        return False
+
+    if obj_node is not None:
+        # System.out.println / System.err.println
+        if obj_node.type == "field_access":
+            receiver = obj_node.child_by_field_name("object")
+            if receiver is not None and receiver.text in _SIDE_EFFECT_RECEIVERS:
+                return True
+        # logger.info, log.debug, etc.
+        if obj_node.type == "identifier" and obj_node.text in _SIDE_EFFECT_RECEIVERS:
+            if method_name.text in _SIDE_EFFECT_METHODS:
+                return True
+
+    # Standalone side-effect method names
+    if method_name.text in _SIDE_EFFECT_METHODS and obj_node is None:
+        return True
+
+    return False
+
+
 class FunctionalChecker:
     """Detects frozen mutation traps, imperative null checks, and impure methods."""
 
@@ -357,25 +388,10 @@ class FunctionalChecker:
 
     @staticmethod
     def _is_side_effect_invocation(invocation: Node) -> bool:
-        """Check if a method_invocation node is a side-effect call."""
-        obj_node = invocation.child_by_field_name("object")
-        method_name = invocation.child_by_field_name("name")
-        if method_name is None:
-            return False
+        """Check if a method_invocation node is a side-effect call.
 
-        if obj_node is not None:
-            # System.out.println / System.err.println
-            if obj_node.type == "field_access":
-                receiver = obj_node.child_by_field_name("object")
-                if receiver is not None and receiver.text in _SIDE_EFFECT_RECEIVERS:
-                    return True
-            # logger.info, log.debug, etc.
-            if obj_node.type == "identifier" and obj_node.text in _SIDE_EFFECT_RECEIVERS:
-                if method_name.text in _SIDE_EFFECT_METHODS:
-                    return True
-
-        # Standalone side-effect method names
-        if method_name.text in _SIDE_EFFECT_METHODS and obj_node is None:
-            return True
-
-        return False
+        Thin delegator kept for backward compatibility; the real logic lives in
+        the module-level ``is_side_effect_invocation`` so other modules (e.g.
+        ``fixes.py``) can reuse it without importing the class.
+        """
+        return is_side_effect_invocation(invocation)

--- a/src/java_functional_lsp/fixes.py
+++ b/src/java_functional_lsp/fixes.py
@@ -14,6 +14,7 @@ from lsprotocol import types as lsp
 from tree_sitter import Node, Tree
 
 from .analyzers.base import extract_null_check_var, find_ancestor, find_nodes, get_parser
+from .analyzers.functional_checker import is_side_effect_invocation
 
 logger = logging.getLogger(__name__)
 
@@ -660,12 +661,212 @@ def fix_null_return(
     return lsp.WorkspaceEdit(changes={uri: edits})
 
 
+# --- try-catch-to-monadic ---
+
+
+def _find_try_node(tree: Tree, diag_range: lsp.Range) -> Node | None:
+    """Find the try_statement node at the given diagnostic range."""
+    target = tree.root_node.descendant_for_point_range(
+        (diag_range.start.line, diag_range.start.character),
+        (diag_range.end.line, diag_range.end.character),
+    )
+    if target is None:
+        return None
+    if target.type == "try_statement":
+        return target
+    return find_ancestor(target, "try_statement")
+
+
+def _first_method_invocation(stmt: Node) -> Node | None:
+    """Return the first method_invocation descendant of stmt, or None."""
+    for inv in find_nodes(stmt, "method_invocation"):
+        return inv
+    return None
+
+
+def _references_var(node: Node, var_name: bytes) -> bool:
+    """True if any identifier descendant of node has text equal to var_name."""
+    cursor = node.walk()
+    visited_children = False
+    while True:
+        if not visited_children:
+            cur = cursor.node
+            if cur is not None and cur.type == "identifier" and cur.text == var_name:
+                return True
+            if not cursor.goto_first_child():
+                visited_children = True
+        elif cursor.goto_next_sibling():
+            visited_children = False
+        elif not cursor.goto_parent():
+            break
+    return False
+
+
+def _extract_try_catch_parts(
+    try_node: Node,
+) -> tuple[Node, str, str, list[Node], Node] | None:
+    """Extract (try_return_expr, catch_type_text, exc_var_name, prior_stmts, catch_return_expr).
+
+    Returns None if the shape doesn't match the supported try-catch-to-monadic pattern:
+    - No finally clause
+    - Exactly one catch clause
+    - Try body is a block with a single return_statement that has an expression
+    - Catch body ends with a return_statement; prior statements are expression_statements
+    """
+    # Reject if finally present
+    if any(c.type == "finally_clause" for c in try_node.children):
+        return None
+
+    # Exactly one catch clause
+    catches = [c for c in try_node.children if c.type == "catch_clause"]
+    if len(catches) != 1:
+        return None
+    catch = catches[0]
+
+    # Try body must be a block with a single return_statement with an expression
+    body = try_node.child_by_field_name("body")
+    if body is None or body.type != "block":
+        return None
+    try_stmts = [c for c in body.named_children if c.type not in ("line_comment", "block_comment")]
+    if len(try_stmts) != 1 or try_stmts[0].type != "return_statement":
+        return None
+    try_ret_children = [c for c in try_stmts[0].named_children if c.type not in ("line_comment", "block_comment")]
+    if not try_ret_children:
+        return None
+    try_return_expr = try_ret_children[0]
+
+    # Extract catch parameter: type + name
+    param = next((c for c in catch.children if c.type == "catch_formal_parameter"), None)
+    if param is None:
+        return None
+    catch_type_node = next((c for c in param.children if c.type == "catch_type"), None)
+    # The name is an identifier child of the catch_formal_parameter
+    exc_name_node = next((c for c in param.children if c.type == "identifier"), None)
+    if catch_type_node is None or exc_name_node is None:
+        return None
+    catch_type_text = catch_type_node.text.decode("utf-8") if catch_type_node.text else ""
+    exc_var_name = exc_name_node.text.decode("utf-8") if exc_name_node.text else ""
+    if not catch_type_text or not exc_var_name:
+        return None
+    # Reject union types (multi-catch): "A | B"
+    if "|" in catch_type_text:
+        return None
+
+    # Catch body: 0+ expression_statements then return_statement
+    catch_body = catch.child_by_field_name("body")
+    if catch_body is None or catch_body.type != "block":
+        return None
+    catch_stmts = [c for c in catch_body.named_children if c.type not in ("line_comment", "block_comment")]
+    if not catch_stmts or catch_stmts[-1].type != "return_statement":
+        return None
+    prior_stmts = catch_stmts[:-1]
+    if any(s.type != "expression_statement" for s in prior_stmts):
+        return None
+    ret_children = [c for c in catch_stmts[-1].named_children if c.type not in ("line_comment", "block_comment")]
+    if not ret_children:
+        return None
+    catch_return_expr = ret_children[0]
+
+    return (try_return_expr, catch_type_text, exc_var_name, prior_stmts, catch_return_expr)
+
+
+def fix_try_catch_to_monadic(
+    uri: str,
+    source: str,
+    diag_range: lsp.Range,
+    config: dict[str, Any],
+    *,
+    tree: Tree | None = None,
+    lines: list[str] | None = None,
+) -> lsp.WorkspaceEdit | None:
+    """Generate a fix for try-catch-to-monadic: rewrite try/catch to Try.of() monadic chain.
+
+    Supports three patterns:
+    - Pattern 1: simple catch with default → ``Try.of(() -> expr).getOrElse(default)``
+    - Pattern 2: logging + default → ``Try.of(() -> expr).onFailure(e -> log).getOrElse(default)``
+    - Pattern 3: exception-dependent recovery → ``Try.of(() -> expr).recover(E.class, e -> f(e)).get()``
+
+    Pass ``lines`` to avoid re-splitting the source when called from a context that has
+    already split it (e.g. ``on_code_action`` in server.py).
+    """
+    if lines is None:
+        lines = source.split("\n")
+    if tree is None:
+        tree = get_parser().parse(source.encode("utf-8"))
+
+    try_node = _find_try_node(tree, diag_range)
+    if try_node is None:
+        return None
+
+    parts = _extract_try_catch_parts(try_node)
+    if parts is None:
+        return None
+    try_return_expr, catch_type_text, exc_var_name, prior_stmts, catch_return_expr = parts
+
+    # Pattern 2 gating: only allow a single prior statement that is a recognized side-effect call
+    on_failure: str | None = None
+    if len(prior_stmts) > 1:
+        return None
+    if len(prior_stmts) == 1:
+        prior = prior_stmts[0]
+        invocation = _first_method_invocation(prior)
+        if invocation is None or not is_side_effect_invocation(invocation):
+            return None
+        prior_text = prior.text.decode("utf-8") if prior.text else ""
+        stmt_text = prior_text.rstrip().rstrip(";").strip()
+        on_failure = f".onFailure({exc_var_name} -> {stmt_text})"
+
+    # Build Try.of(() -> <try_return_expr>) [+ .onFailure(...)]
+    try_body_text = try_return_expr.text.decode("utf-8") if try_return_expr.text else ""
+    chain = f"Try.of(() -> {try_body_text})"
+    if on_failure is not None:
+        chain += on_failure
+
+    # Pattern 3 vs Pattern 1: does the catch-return expression reference the exception var?
+    catch_expr_text = catch_return_expr.text.decode("utf-8") if catch_return_expr.text else ""
+    if _references_var(catch_return_expr, exc_var_name.encode("utf-8")):
+        # Pattern 3: .recover(Type.class, e -> expr).get()
+        chain += f".recover({catch_type_text}.class, {exc_var_name} -> {catch_expr_text}).get()"
+    elif _is_eager(catch_return_expr):
+        # Pattern 1 (eager): literal/identifier default
+        chain += f".getOrElse({catch_expr_text})"
+    else:
+        # Pattern 1 (lazy): method call or complex expression
+        chain += f".getOrElse(() -> {catch_expr_text})"
+
+    # Build edits
+    edits: list[lsp.TextEdit] = []
+    if config.get("autoImportVavr", True):
+        import_edit = ensure_import(lines, "io.vavr.control.Try")
+        if import_edit is not None:
+            edits.append(import_edit)
+
+    replace_start = lsp.Position(line=try_node.start_point[0], character=try_node.start_point[1])
+    replace_end = lsp.Position(line=try_node.end_point[0], character=try_node.end_point[1])
+    edits.append(
+        lsp.TextEdit(
+            range=lsp.Range(start=replace_start, end=replace_end),
+            new_text=f"return {chain};",
+        )
+    )
+
+    logger.debug(
+        "try-catch-to-monadic rewrite: pattern=%s, lines %d-%d",
+        "recover" if ".recover(" in chain else ("onFailure" if on_failure else "getOrElse"),
+        try_node.start_point[0],
+        try_node.end_point[0],
+    )
+
+    return lsp.WorkspaceEdit(changes={uri: edits})
+
+
 # --- Fix registry ---
 
 _FIX_REGISTRY: dict[str, FixGenerator] = {
     "frozen-mutation": fix_frozen_mutation,
     "null-check-to-monadic": fix_null_check_to_monadic,
     "null-return": fix_null_return,
+    "try-catch-to-monadic": fix_try_catch_to_monadic,
 }
 
 

--- a/src/java_functional_lsp/fixes.py
+++ b/src/java_functional_lsp/fixes.py
@@ -13,7 +13,15 @@ from typing import Any
 from lsprotocol import types as lsp
 from tree_sitter import Node, Tree
 
-from .analyzers.base import extract_null_check_var, find_ancestor, find_nodes, get_parser
+from .analyzers.base import (
+    IGNORED_CHILDREN,
+    extract_null_check_var,
+    find_ancestor,
+    find_nodes,
+    get_parser,
+    has_error_or_missing,
+    references_var,
+)
 from .analyzers.functional_checker import is_side_effect_invocation
 
 logger = logging.getLogger(__name__)
@@ -665,7 +673,16 @@ def fix_null_return(
 
 
 def _find_try_node(tree: Tree, diag_range: lsp.Range) -> Node | None:
-    """Find the try_statement node at the given diagnostic range."""
+    """Find the try_statement node at the given diagnostic range.
+
+    The diagnostic range typically points at the ``try`` keyword (narrow range
+    emitted by the analyzer), but editors may send a broader range that lands
+    on a descendant token. ``descendant_for_point_range`` returns the deepest
+    node containing the range; if that node is not the ``try_statement`` itself
+    we walk up via ``find_ancestor``. Unlike ``_find_method_invocation``, we do
+    not search children because the ``try_statement`` is always an ancestor of
+    any token inside a try/catch block.
+    """
     target = tree.root_node.descendant_for_point_range(
         (diag_range.start.line, diag_range.start.character),
         (diag_range.end.line, diag_range.end.character),
@@ -678,47 +695,58 @@ def _find_try_node(tree: Tree, diag_range: lsp.Range) -> Node | None:
 
 
 def _first_method_invocation(stmt: Node) -> Node | None:
-    """Return the first method_invocation descendant of stmt, or None."""
+    """Return the first ``method_invocation`` descendant of ``stmt``, or None.
+
+    Used by Pattern 2 logging detection to locate the side-effect call inside
+    a catch-body prior statement. For a simple statement like
+    ``logger.warn("msg", e);`` this returns the ``logger.warn`` invocation.
+
+    Limitation: if the outer expression is a non-logging call wrapping a
+    logging call (e.g. ``cache.put(k, logger.warn(...))``), this returns the
+    outer call and the caller's ``is_side_effect_invocation`` check rejects
+    it — which is the safe behaviour (no fix rather than incorrect fix).
+    """
     for inv in find_nodes(stmt, "method_invocation"):
         return inv
     return None
 
 
-def _references_var(node: Node, var_name: bytes) -> bool:
-    """True if any identifier descendant of node has text equal to var_name."""
-    cursor = node.walk()
-    visited_children = False
-    while True:
-        if not visited_children:
-            cur = cursor.node
-            if cur is not None and cur.type == "identifier" and cur.text == var_name:
-                return True
-            if not cursor.goto_first_child():
-                visited_children = True
-        elif cursor.goto_next_sibling():
-            visited_children = False
-        elif not cursor.goto_parent():
-            break
-    return False
-
-
-def _extract_try_catch_parts(
+def _validate_and_extract_try_catch_parts(
     try_node: Node,
 ) -> tuple[Node, str, str, list[Node], Node] | None:
-    """Extract (try_return_expr, catch_type_text, exc_var_name, prior_stmts, catch_return_expr).
+    """Validate try/catch shape and extract parts needed to build the rewrite.
 
-    Returns None if the shape doesn't match the supported try-catch-to-monadic pattern:
-    - No finally clause
-    - Exactly one catch clause
+    Returns ``(try_return_expr, catch_type_text, exc_var_name, prior_stmts, catch_return_expr)``
+    or ``None`` if the shape doesn't match.
+
+    This function re-validates the same shape as
+    ``exception_checker._matches_try_catch_monadic_shape`` as a defense in depth:
+    the fix generator must be robust when called directly (e.g. from tests, or
+    when the diagnostic is stale). Both functions must stay in sync — any shape
+    rejected by one must also be rejected by the other.
+
+    Requirements (must mirror the analyzer):
+    - No resource_specification (try-with-resources)
+    - No finally_clause
+    - Exactly one catch_clause
+    - Catch type must not be a union (``A | B``)
     - Try body is a block with a single return_statement that has an expression
-    - Catch body ends with a return_statement; prior statements are expression_statements
+    - Catch body ends with a return_statement with an expression; prior stmts are expression_statements
     """
-    # Reject if finally present
-    if any(c.type == "finally_clause" for c in try_node.children):
-        return None
+    # Single pass over try_node.children
+    has_finally = False
+    has_resources = False
+    catches: list[Node] = []
+    for c in try_node.children:
+        if c.type == "finally_clause":
+            has_finally = True
+        elif c.type == "resource_specification":
+            has_resources = True
+        elif c.type == "catch_clause":
+            catches.append(c)
 
-    # Exactly one catch clause
-    catches = [c for c in try_node.children if c.type == "catch_clause"]
+    if has_finally or has_resources:
+        return None
     if len(catches) != 1:
         return None
     catch = catches[0]
@@ -727,10 +755,10 @@ def _extract_try_catch_parts(
     body = try_node.child_by_field_name("body")
     if body is None or body.type != "block":
         return None
-    try_stmts = [c for c in body.named_children if c.type not in ("line_comment", "block_comment")]
+    try_stmts = [c for c in body.named_children if c.type not in IGNORED_CHILDREN]
     if len(try_stmts) != 1 or try_stmts[0].type != "return_statement":
         return None
-    try_ret_children = [c for c in try_stmts[0].named_children if c.type not in ("line_comment", "block_comment")]
+    try_ret_children = [c for c in try_stmts[0].named_children if c.type not in IGNORED_CHILDREN]
     if not try_ret_children:
         return None
     try_return_expr = try_ret_children[0]
@@ -756,18 +784,31 @@ def _extract_try_catch_parts(
     catch_body = catch.child_by_field_name("body")
     if catch_body is None or catch_body.type != "block":
         return None
-    catch_stmts = [c for c in catch_body.named_children if c.type not in ("line_comment", "block_comment")]
+    catch_stmts = [c for c in catch_body.named_children if c.type not in IGNORED_CHILDREN]
     if not catch_stmts or catch_stmts[-1].type != "return_statement":
         return None
     prior_stmts = catch_stmts[:-1]
     if any(s.type != "expression_statement" for s in prior_stmts):
         return None
-    ret_children = [c for c in catch_stmts[-1].named_children if c.type not in ("line_comment", "block_comment")]
+    ret_children = [c for c in catch_stmts[-1].named_children if c.type not in IGNORED_CHILDREN]
     if not ret_children:
         return None
     catch_return_expr = ret_children[0]
 
     return (try_return_expr, catch_type_text, exc_var_name, prior_stmts, catch_return_expr)
+
+
+def _strip_trailing_semicolon(text: str) -> str:
+    """Strip exactly one trailing ';' from a statement's text (not all trailing semicolons).
+
+    ``str.rstrip(';')`` treats its argument as a **character set**, so it would
+    greedily strip any number of trailing semicolons. For a well-formed
+    ``expression_statement``, the text ends in exactly one ``;``. Use
+    ``removesuffix`` to strip at most one, preserving any semantically
+    meaningful content.
+    """
+    stripped = text.rstrip()
+    return stripped.removesuffix(";").rstrip()
 
 
 def fix_try_catch_to_monadic(
@@ -779,15 +820,42 @@ def fix_try_catch_to_monadic(
     tree: Tree | None = None,
     lines: list[str] | None = None,
 ) -> lsp.WorkspaceEdit | None:
-    """Generate a fix for try-catch-to-monadic: rewrite try/catch to Try.of() monadic chain.
+    """Generate a fix for try-catch-to-monadic: rewrite try/catch to a Vavr ``Try.of()`` chain.
 
     Supports three patterns:
-    - Pattern 1: simple catch with default → ``Try.of(() -> expr).getOrElse(default)``
-    - Pattern 2: logging + default → ``Try.of(() -> expr).onFailure(e -> log).getOrElse(default)``
-    - Pattern 3: exception-dependent recovery → ``Try.of(() -> expr).recover(E.class, e -> f(e)).get()``
 
-    Pass ``lines`` to avoid re-splitting the source when called from a context that has
-    already split it (e.g. ``on_code_action`` in server.py).
+    - **Pattern 1** — simple catch with default:
+      ``try { return expr; } catch (E e) { return default; }``
+      → ``return Try.of(() -> expr).getOrElse(default);``
+      (eager vs lazy ``.getOrElse(...)`` via ``_is_eager``)
+
+    - **Pattern 2** — logging + default:
+      ``try { return expr; } catch (E e) { log(e); return default; }``
+      → ``return Try.of(() -> expr).onFailure(e -> log(e)).getOrElse(default);``
+      (prior statement must be a recognized side-effect invocation; otherwise
+      no fix is produced)
+
+    - **Pattern 3** — exception-dependent recovery:
+      ``try { return expr; } catch (E e) { return f(e); }``
+      → ``return Try.of(() -> expr).recover(E.class, e -> f(e)).get();``
+
+    **Semantic limitation of Pattern 3:** ``.recover(E.class, ...).get()``
+    re-throws any failure whose type is NOT ``E``. The original Java code
+    would propagate non-E exceptions through the catch unchanged — for
+    checked exceptions this is identical, but if ``risky()`` also throws
+    unchecked exceptions beyond ``E``, the original code would propagate
+    them as-is while the rewrite wraps them through Vavr's exception
+    handling machinery. In practice the behaviour is equivalent for
+    well-formed Java code where the catch type matches the method's
+    declared throws list.
+
+    **Rejected combinations:** Pattern 2 + Pattern 3 (logging + exception-
+    dependent recovery) is explicitly rejected rather than silently emitting
+    a hybrid ``.onFailure(...).recover(...)`` chain, since that combination
+    is neither tested nor documented.
+
+    Pass ``lines`` to avoid re-splitting the source when called from a context
+    that has already split it (e.g. ``on_code_action`` in server.py).
     """
     if lines is None:
         lines = source.split("\n")
@@ -796,35 +864,57 @@ def fix_try_catch_to_monadic(
 
     try_node = _find_try_node(tree, diag_range)
     if try_node is None:
+        logger.debug("try-catch-to-monadic: no try_statement found at range %s", diag_range)
         return None
 
-    parts = _extract_try_catch_parts(try_node)
+    # Defensive gate: refuse to rewrite subtrees with ERROR or MISSING nodes.
+    # Editors send partial trees during incremental typing; emitting edits for
+    # those would produce invalid Java.
+    if has_error_or_missing(try_node):
+        logger.debug("try-catch-to-monadic: try_statement contains ERROR/MISSING nodes, skipping")
+        return None
+
+    parts = _validate_and_extract_try_catch_parts(try_node)
     if parts is None:
+        logger.debug("try-catch-to-monadic: shape validation failed")
         return None
     try_return_expr, catch_type_text, exc_var_name, prior_stmts, catch_return_expr = parts
 
-    # Pattern 2 gating: only allow a single prior statement that is a recognized side-effect call
+    try_body_text = try_return_expr.text.decode("utf-8") if try_return_expr.text else ""
+    catch_expr_text = catch_return_expr.text.decode("utf-8") if catch_return_expr.text else ""
+    if not try_body_text or not catch_expr_text:
+        logger.debug("try-catch-to-monadic: empty try/catch expression text")
+        return None
+
+    uses_exc = references_var(catch_return_expr, exc_var_name.encode("utf-8"))
+
+    # Pattern 2 gating: only allow a single prior statement that is a recognized
+    # side-effect call. Also reject Pattern 2 + Pattern 3 hybrid explicitly.
     on_failure: str | None = None
     if len(prior_stmts) > 1:
+        logger.debug("try-catch-to-monadic: too many prior statements (%d)", len(prior_stmts))
         return None
     if len(prior_stmts) == 1:
+        if uses_exc:
+            # Pattern 2 + Pattern 3 hybrid is out of scope for v1.
+            logger.debug("try-catch-to-monadic: Pattern 2+3 hybrid rejected")
+            return None
         prior = prior_stmts[0]
         invocation = _first_method_invocation(prior)
         if invocation is None or not is_side_effect_invocation(invocation):
+            logger.debug("try-catch-to-monadic: prior statement is not a recognized side-effect call")
             return None
         prior_text = prior.text.decode("utf-8") if prior.text else ""
-        stmt_text = prior_text.rstrip().rstrip(";").strip()
+        stmt_text = _strip_trailing_semicolon(prior_text)
         on_failure = f".onFailure({exc_var_name} -> {stmt_text})"
 
     # Build Try.of(() -> <try_return_expr>) [+ .onFailure(...)]
-    try_body_text = try_return_expr.text.decode("utf-8") if try_return_expr.text else ""
     chain = f"Try.of(() -> {try_body_text})"
     if on_failure is not None:
         chain += on_failure
 
     # Pattern 3 vs Pattern 1: does the catch-return expression reference the exception var?
-    catch_expr_text = catch_return_expr.text.decode("utf-8") if catch_return_expr.text else ""
-    if _references_var(catch_return_expr, exc_var_name.encode("utf-8")):
+    if uses_exc:
         # Pattern 3: .recover(Type.class, e -> expr).get()
         chain += f".recover({catch_type_text}.class, {exc_var_name} -> {catch_expr_text}).get()"
     elif _is_eager(catch_return_expr):
@@ -852,7 +942,7 @@ def fix_try_catch_to_monadic(
 
     logger.debug(
         "try-catch-to-monadic rewrite: pattern=%s, lines %d-%d",
-        "recover" if ".recover(" in chain else ("onFailure" if on_failure else "getOrElse"),
+        "recover" if uses_exc else ("onFailure+getOrElse" if on_failure else "getOrElse"),
         try_node.start_point[0],
         try_node.end_point[0],
     )

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -386,6 +386,7 @@ _FIX_TITLES: dict[str, str] = {
     "frozen-mutation": "Switch to Vavr Immutable Collection",
     "null-check-to-monadic": "Convert to Option monadic flow",
     "null-return": "Replace with Option.none()",
+    "try-catch-to-monadic": "Convert try/catch to Try monadic flow",
 }
 
 # Guard against title/registry mismatch at import time

--- a/tests/test_exception_checker.py
+++ b/tests/test_exception_checker.py
@@ -129,3 +129,168 @@ class TestBeanSuppression:
         diags = parse_and_analyze(ExceptionChecker(), source)
         assert not any(d.code == "catch-rethrow" for d in diags)
         assert not any(d.code == "throw-statement" for d in diags)
+
+
+class TestTryCatchToMonadic:
+    def test_detects_simple_try_return(self) -> None:
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (IOException e) { return "default"; }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_detects_logging_then_return(self) -> None:
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (IOException e) {
+                    logger.warn("failed", e);
+                    return "fallback";
+                }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_detects_recover_pattern(self) -> None:
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (IOException e) { return fallback(e); }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_diagnostic_on_try_keyword(self) -> None:
+        """Diagnostic range should cover only the `try` keyword (3 chars)."""
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (Exception e) { return "x"; }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        d = next(x for x in diags if x.code == "try-catch-to-monadic")
+        # Narrow range: only the `try` keyword
+        assert d.line == d.end_line
+        assert d.end_col - d.col == 3  # len("try")
+
+    def test_ignores_try_with_finally(self) -> None:
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (Exception e) { return "x"; }
+                finally { cleanup(); }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert not any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_ignores_multi_catch(self) -> None:
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (IOException e) { return "io"; }
+                catch (SQLException e) { return "sql"; }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert not any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_ignores_multi_statement_try_body(self) -> None:
+        source = b"""
+        class T {
+            String f() {
+                try {
+                    String x = risky();
+                    return x.trim();
+                } catch (Exception e) { return "x"; }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert not any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_ignores_try_without_return(self) -> None:
+        source = b"""
+        class T {
+            void f() {
+                try { risky(); }
+                catch (Exception e) { log(e); }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert not any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_severity_is_hint_by_default(self) -> None:
+        from java_functional_lsp.analyzers.base import Severity
+
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (Exception e) { return "x"; }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        d = next(x for x in diags if x.code == "try-catch-to-monadic")
+        assert d.severity == Severity.HINT
+
+    def test_suppressed_in_bean_method(self) -> None:
+        source = b"""
+        class Config {
+            @Bean
+            DataSource dataSource() {
+                try { return connect(); }
+                catch (Exception e) { return fallback; }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert not any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_has_diagnostic_data(self) -> None:
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (Exception e) { return "x"; }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        d = next(x for x in diags if x.code == "try-catch-to-monadic")
+        assert d.data is not None
+        assert d.data.fix_type == "WRAP_IN_TRY"
+        assert d.data.target_library == "io.vavr.control.Try"
+
+    def test_disabled_by_config(self) -> None:
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (Exception e) { return "x"; }
+            }
+        }
+        """
+        config = {"rules": {"try-catch-to-monadic": "off"}}
+        diags = parse_and_analyze(ExceptionChecker(), source, config)
+        assert not any(d.code == "try-catch-to-monadic" for d in diags)

--- a/tests/test_exception_checker.py
+++ b/tests/test_exception_checker.py
@@ -294,3 +294,114 @@ class TestTryCatchToMonadic:
         config = {"rules": {"try-catch-to-monadic": "off"}}
         diags = parse_and_analyze(ExceptionChecker(), source, config)
         assert not any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_ignores_union_catch_type(self) -> None:
+        """Multi-catch (A | B e) is not supported — no diagnostic should be emitted."""
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (IOException | SQLException e) { return "x"; }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert not any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_ignores_try_with_resources(self) -> None:
+        """try-with-resources must not be rewritten — closing the resource would be lost."""
+        source = b"""
+        class T {
+            String f() {
+                try (java.io.InputStream is = open()) {
+                    return parse(is);
+                } catch (java.io.IOException e) {
+                    return "empty";
+                }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        assert not any(d.code == "try-catch-to-monadic" for d in diags)
+
+    def test_catch_with_throw_only_flags_rethrow_not_monadic(self) -> None:
+        """A catch whose sole statement is a throw should fire catch-rethrow, NOT try-catch-to-monadic."""
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (Exception e) { throw new RuntimeException(e); }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        codes = [d.code for d in diags]
+        # catch-rethrow fires (the existing rule)
+        assert "catch-rethrow" in codes
+        # but try-catch-to-monadic does NOT — the catch body is a throw, not a return
+        assert "try-catch-to-monadic" not in codes
+
+    def test_detects_two_sequential_try_catches(self) -> None:
+        """Two independent try/catch blocks in the same class produce two diagnostics."""
+        source = b"""
+        class T {
+            String f() {
+                try { return a(); } catch (Exception e) { return "a-default"; }
+            }
+            String g() {
+                try { return b(); } catch (Exception e) { return "b-default"; }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        monadic = [d for d in diags if d.code == "try-catch-to-monadic"]
+        assert len(monadic) == 2
+
+    def test_no_duplicate_diagnostic_for_single_try(self) -> None:
+        """Regression guard: a single matching try/catch produces exactly one diagnostic."""
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (Exception e) { return "x"; }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        monadic = [d for d in diags if d.code == "try-catch-to-monadic"]
+        assert len(monadic) == 1
+
+    def test_nested_try_catch_outer_only(self) -> None:
+        """Outer try/catch that contains an inner non-matching block still matches on the outer."""
+        source = b"""
+        class T {
+            String f() {
+                try {
+                    return inner();
+                } catch (Exception e) {
+                    return "outer";
+                }
+            }
+        }
+        """
+        diags = parse_and_analyze(ExceptionChecker(), source)
+        monadic = [d for d in diags if d.code == "try-catch-to-monadic"]
+        # The outer try matches the shape exactly once.
+        assert len(monadic) == 1
+
+    def test_severity_via_config_warning(self) -> None:
+        """Non-default severity level propagates through the config."""
+        from java_functional_lsp.analyzers.base import Severity
+
+        source = b"""
+        class T {
+            String f() {
+                try { return risky(); }
+                catch (Exception e) { return "x"; }
+            }
+        }
+        """
+        config = {"rules": {"try-catch-to-monadic": "warning"}}
+        diags = parse_and_analyze(ExceptionChecker(), source, config)
+        d = next(x for x in diags if x.code == "try-catch-to-monadic")
+        assert d.severity == Severity.WARNING

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -936,3 +936,181 @@ class TestFixTryCatchToMonadic:
         # The range should start at the `try` keyword (line 2, col 8)
         assert rewrite.range.start.line == 2
         assert rewrite.range.start.character == 8
+        # The range should end at the closing brace of the try/catch block on line 6, col 9.
+        # Source has try { ... } on line 2 through line 6 (closing brace column 9).
+        assert rewrite.range.end.line == 6
+        assert rewrite.range.end.character == 9
+
+    def test_exact_equality_on_new_text(self) -> None:
+        """Pin the full rewrite output for one canonical Pattern 1 case."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (IOException e) {\n"
+            '            return "default";\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = next(e for e in edits if "Try.of" in e.new_text)
+        assert rewrite.new_text == 'return Try.of(() -> risky()).getOrElse("default");'
+
+    def test_pattern2_with_non_e_variable_name(self) -> None:
+        """Pattern 2 must use the actual catch variable name, not hardcoded `e`."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (IOException ex) {\n"
+            '            logger.warn("failed", ex);\n'
+            '            return "default";\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = next(e for e in edits if "Try.of" in e.new_text)
+        assert '.onFailure(ex -> logger.warn("failed", ex))' in rewrite.new_text
+        assert '.getOrElse("default")' in rewrite.new_text
+
+    def test_bare_return_in_catch_returns_none(self) -> None:
+        """A catch body ending with bare `return;` (no expression) is not rewritable."""
+        source = (
+            "class T {\n"
+            "    void f() {\n"
+            "        try {\n"
+            "            return;\n"
+            "        } catch (Exception e) {\n"
+            "            return;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is None
+
+    def test_pattern2_multiple_prior_statements_returns_none(self) -> None:
+        """Two logger calls before the return exceed Pattern 2 scope → no fix."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (Exception e) {\n"
+            '            logger.warn("first", e);\n'
+            '            logger.warn("second", e);\n'
+            '            return "default";\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is None
+
+    def test_pattern2_plus_pattern3_hybrid_returns_none(self) -> None:
+        """Logging + exception-dependent recovery is explicitly rejected (untested hybrid)."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (IOException e) {\n"
+            '            logger.warn("failed", e);\n'
+            "            return fallback(e);\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is None
+
+    def test_ancestor_walk_finds_try_from_inside(self) -> None:
+        """A diagnostic range pointing inside the try body still resolves to the try_statement."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (Exception e) {\n"
+            "            return fallback;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        # Point the range at `risky` inside the return statement (line 3, cols 19-24).
+        inner_range = _range(3, 19, 3, 24)
+        result = fix_try_catch_to_monadic("file:///test.java", source, inner_range, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = next(e for e in edits if "Try.of" in e.new_text)
+        assert "Try.of(() -> risky()).getOrElse(fallback)" in rewrite.new_text
+
+    def test_import_edit_position_is_top_of_file(self) -> None:
+        """The Try import should be inserted at line 0 when there's no package or existing import."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try { return risky(); }\n"
+            "        catch (Exception e) { return fallback; }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        import_edit = next(e for e in edits if "import io.vavr.control.Try;" in e.new_text)
+        assert import_edit.range.start.line == 0
+        assert import_edit.range.start.character == 0
+
+    def test_union_catch_returns_none(self) -> None:
+        """Multi-catch (A | B e) is explicitly rejected by the fix."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try { return risky(); }\n"
+            "        catch (IOException | SQLException e) { return fallback; }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is None
+
+    def test_try_with_resources_returns_none(self) -> None:
+        """try-with-resources must not be rewritten — closing the resource would be lost."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try (java.io.InputStream is = open()) {\n"
+            "            return parse(is);\n"
+            "        } catch (java.io.IOException e) {\n"
+            '            return "empty";\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is None
+
+    def test_strip_trailing_semicolon_helper(self) -> None:
+        """The trailing-semicolon helper strips exactly one semicolon, not greedily."""
+        from java_functional_lsp.fixes import _strip_trailing_semicolon
+
+        assert _strip_trailing_semicolon('logger.warn("x", e);') == 'logger.warn("x", e)'
+        # removesuffix strips at most one, not all
+        assert _strip_trailing_semicolon('logger.warn("x", e);;') == 'logger.warn("x", e);'
+        # Trailing whitespace is handled
+        assert _strip_trailing_semicolon('logger.warn("x", e);  ') == 'logger.warn("x", e)'
+        # No trailing semicolon → no change
+        assert _strip_trailing_semicolon('logger.warn("x", e)') == 'logger.warn("x", e)'

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -9,6 +9,7 @@ from java_functional_lsp.fixes import (
     fix_frozen_mutation,
     fix_null_check_to_monadic,
     fix_null_return,
+    fix_try_catch_to_monadic,
     get_fix_registry_keys,
 )
 
@@ -653,3 +654,285 @@ class TestFixNullReturn:
         edits = result.changes["file:///test.java"]
         assert len(edits) == 1
         assert "Option.none()" in edits[0].new_text
+
+
+class TestFixTryCatchToMonadic:
+    # The canonical test source places the `try` keyword at line 2, cols 8-11
+    # (under a top-level class declaration with a single-method body).
+    _TRY_RANGE = _range(2, 8, 2, 11)
+
+    def test_pattern1_eager_literal(self) -> None:
+        """String literal default → eager .getOrElse("default") with no lambda."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (IOException e) {\n"
+            '            return "default";\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = next(e for e in edits if "Try.of" in e.new_text)
+        assert "Try.of(() -> risky())" in rewrite.new_text
+        assert '.getOrElse("default")' in rewrite.new_text
+        # Eager — no lambda wrapping on the default
+        assert '() -> "default"' not in rewrite.new_text
+
+    def test_pattern1_eager_identifier(self) -> None:
+        """Bare identifier → eager .getOrElse(identifier)."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (IOException e) {\n"
+            "            return fallback;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = next(e for e in edits if "Try.of" in e.new_text)
+        assert ".getOrElse(fallback)" in rewrite.new_text
+        assert "() -> fallback" not in rewrite.new_text
+
+    def test_pattern1_lazy_method_call(self) -> None:
+        """Method-call default → lazy .getOrElse(() -> computeDefault())."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (IOException e) {\n"
+            "            return computeDefault();\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = next(e for e in edits if "Try.of" in e.new_text)
+        assert ".getOrElse(() -> computeDefault())" in rewrite.new_text
+
+    def test_pattern2_logging_onfailure(self) -> None:
+        """Logging + return → Try.of().onFailure(e -> log).getOrElse(default)."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (IOException e) {\n"
+            '            logger.warn("failed", e);\n'
+            '            return "default";\n'
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = next(e for e in edits if "Try.of" in e.new_text)
+        assert '.onFailure(e -> logger.warn("failed", e))' in rewrite.new_text
+        assert '.getOrElse("default")' in rewrite.new_text
+
+    def test_pattern3_recover_with_exception_var(self) -> None:
+        """Recovery uses exception var → .recover(Type.class, e -> expr).get()."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (IOException e) {\n"
+            "            return fallback(e);\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = next(e for e in edits if "Try.of" in e.new_text)
+        assert ".recover(IOException.class, e -> fallback(e))" in rewrite.new_text
+        assert ".get()" in rewrite.new_text
+        # Must not use getOrElse in Pattern 3
+        assert ".getOrElse(" not in rewrite.new_text
+
+    def test_pattern3_generic_exception_type(self) -> None:
+        """Generic Exception type works the same as specific types."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (Exception ex) {\n"
+            "            return handle(ex);\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = next(e for e in edits if "Try.of" in e.new_text)
+        assert ".recover(Exception.class, ex -> handle(ex))" in rewrite.new_text
+
+    def test_imports_vavr_try(self) -> None:
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (Exception e) {\n"
+            "            return fallback;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        assert any("import io.vavr.control.Try;" in e.new_text for e in edits)
+
+    def test_no_import_when_disabled(self) -> None:
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (Exception e) {\n"
+            "            return fallback;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {"autoImportVavr": False})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        assert not any("import" in e.new_text for e in edits)
+
+    def test_no_duplicate_import(self) -> None:
+        source = (
+            "import io.vavr.control.Try;\n"
+            "\n"
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (Exception e) {\n"
+            "            return fallback;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        # try keyword is on line 4 now (import + blank + class + method)
+        result = fix_try_catch_to_monadic("file:///test.java", source, _range(4, 8, 4, 11), {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        assert not any("import" in e.new_text for e in edits)
+
+    def test_multi_statement_try_returns_none(self) -> None:
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            String x = risky();\n"
+            "            return x.trim();\n"
+            "        } catch (Exception e) { return fallback; }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is None
+
+    def test_finally_returns_none(self) -> None:
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (Exception e) {\n"
+            "            return fallback;\n"
+            "        } finally {\n"
+            "            cleanup();\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is None
+
+    def test_multi_catch_returns_none(self) -> None:
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (IOException e) {\n"
+            "            return a;\n"
+            "        } catch (SQLException e) {\n"
+            "            return b;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is None
+
+    def test_unknown_prior_statement_returns_none(self) -> None:
+        """Prior statement that isn't a recognized side-effect call → no auto-fix."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (Exception e) {\n"
+            "            cache.put(key, fallback);\n"
+            "            return fallback;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is None
+
+    def test_replaces_full_try_statement(self) -> None:
+        """The fix should replace the entire try_statement range with `return <chain>;`."""
+        source = (
+            "class T {\n"
+            "    String f() {\n"
+            "        try {\n"
+            "            return risky();\n"
+            "        } catch (Exception e) {\n"
+            "            return fallback;\n"
+            "        }\n"
+            "    }\n"
+            "}\n"
+        )
+        result = fix_try_catch_to_monadic("file:///test.java", source, self._TRY_RANGE, {})
+        assert result is not None
+        assert result.changes is not None
+        edits = result.changes["file:///test.java"]
+        rewrite = next(e for e in edits if "Try.of" in e.new_text)
+        # Replacement text should start with "return " and end with ";"
+        assert rewrite.new_text.startswith("return ")
+        assert rewrite.new_text.endswith(";")
+        # The range should start at the `try` keyword (line 2, col 8)
+        assert rewrite.range.start.line == 2
+        assert rewrite.range.start.character == 8

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.6.2"
+version = "0.6.6"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary

- New `try-catch-to-monadic` diagnostic + QuickFix that rewrites imperative try/catch blocks into Vavr `Try.of()` monadic chains
- Closes the gap between existing `impure-method`/`catch-rethrow` suggestions (which mention `Try` but had no auto-fix) and a usable QuickFix
- Refactors `FunctionalChecker._is_side_effect_invocation` to a module-level helper so the fix generator can reuse the logging-detection heuristic

## Supported Patterns

**Pattern 1 — Simple default**
```java
try { return risky(); }
catch (IOException e) { return "default"; }
```
→ `return Try.of(() -> risky()).getOrElse("default");`

Eager vs lazy `.getOrElse(...)` via the existing `_is_eager` helper (literals/identifiers stay eager; method calls become lazy `() -> ...`).

**Pattern 2 — Logging + default**
```java
try { return risky(); }
catch (IOException e) {
    logger.warn("failed", e);
    return "default";
}
```
→ `return Try.of(() -> risky()).onFailure(e -> logger.warn("failed", e)).getOrElse("default");`

Prior statement must be a recognized side-effect call (`logger.*`, `log.*`, `LOG.*`, `System.out.*`, etc.).

**Pattern 3 — Exception-dependent recovery**
```java
try { return risky(); }
catch (IOException e) { return fallback(e); }
```
→ `return Try.of(() -> risky()).recover(IOException.class, e -> fallback(e)).get();`

Distinguished from Pattern 1 by scanning the catch-return expression for references to the exception variable.

## Design Choices

- **Conservative scope**: single catch, no finally, single-return try body, no multi-catch. Out-of-scope shapes emit no diagnostic (and the fix returns `None` as a defense in depth).
- **Narrow diagnostic range**: just the `try` keyword (3 chars), analogous to `impure-method` pointing at the method name.
- **Default severity**: `HINT` (non-blocking), same tier as `impure-method`.
- **@Bean suppression**: same as `throw-statement`/`catch-rethrow` — skipped inside `@Bean` methods.
- **Side-effect helper refactor**: `FunctionalChecker._is_side_effect_invocation` → module-level `is_side_effect_invocation()`. The staticmethod stays as a thin delegator so existing call sites don't churn.
- **Bonus**: the Pattern 2+3 combination (logging + recover) composes naturally into `.onFailure(...).recover(...).get()` — valid Vavr, falls out of the design for free.

## Files Changed

| File | Change |
|------|--------|
| `analyzers/exception_checker.py` | New rule + `_matches_try_catch_monadic_shape` helper |
| `analyzers/functional_checker.py` | Promote `_is_side_effect_invocation` to module-level |
| `fixes.py` | New `fix_try_catch_to_monadic` + 4 helpers; registered in `_FIX_REGISTRY` |
| `server.py` | Added `"try-catch-to-monadic"` title (import-time assertion verifies consistency) |
| `tests/test_exception_checker.py` | 12 new analyzer tests |
| `tests/test_fixes.py` | 14 new fix generator tests |
| `pyproject.toml`, `__init__.py`, `uv.lock` | Version bump 0.6.5 → 0.6.6 |

## Test plan

- [x] `uv run pytest` — **242 passed**, 75% coverage
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format src tests` — formatted
- [x] `uv run pyright src/java_functional_lsp` — 0 errors, 0 warnings
- [x] Pre-commit hook passes (lint + format + type + version + tests)
- [ ] Manual smoke test in an editor: open a Java file with a Pattern 1/2/3 try/catch, trigger the QuickFix on the `try` keyword, verify the rewrite + import insertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)