### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.6.7"
+version = "0.7.0"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.6.7"
+__version__ = "0.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.6.7"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary

Minor version bump `0.6.7` → `0.7.0` for the try-catch-to-monadic feature merged in #40.

Per semver, a new diagnostic rule + QuickFix is a new feature and warrants a minor bump rather than patch.

## Release scope

Versions `0.6.5` and `0.6.6` were never published to PyPI (the v0.6.5 draft release was never finalized). This upcoming `v0.7.0` will therefore cover everything since `v0.6.4`:

- **#39** — fix: increase jdtls heap to 4GB and log stderr for debugging
- **#40** — feat: add try-catch-to-monadic code action with Vavr `Try.of()` rewrites
  - First commit: new rule + code action (3 patterns: `getOrElse`, `onFailure + getOrElse`, `recover.get()`)
  - Second commit: review ensemble fixes — union-catch rejection, try-with-resources rejection, Pattern 2+3 hybrid rejection, `_strip_trailing_semicolon` helper, ERROR/MISSING node gate, 17 new tests, shared helpers extracted to `analyzers/base.py`

## Files changed

- `pyproject.toml` — `version = "0.7.0"`
- `src/java_functional_lsp/__init__.py` — `__version__ = "0.7.0"`
- `uv.lock` — regenerated

## Test plan

- [x] `uv run pytest` — 259 passed, 76% coverage
- [x] `uv run ruff check src tests` — clean
- [x] `uv run pyright src/java_functional_lsp` — 0 errors, 0 warnings
- [x] Pre-commit hook passed

## Post-merge steps

After merge:
1. Delete the stale `v0.6.5` draft release (created by release-drafter after #39)
2. Create `v0.7.0` release on the merge commit
3. Publish it → `.github/workflows/publish.yml` auto-publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)