### PR TITLE
fix: README intro + jdtls initialize timeout for large monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/java-functional-lsp?v=1)](https://pypi.org/project/java-functional-lsp/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A Java Language Server that provides two things in one:
+A Java Language Server that provides three things in one:
 
 1. **Full Java language support** — completions, hover, go-to-definition, compile errors, missing imports — by proxying [Eclipse jdtls](https://github.com/eclipse-jdtls/eclipse.jdt.ls) under the hood
 2. **16 functional programming rules** — catches anti-patterns and suggests Vavr/Lombok/Spring alternatives, all before compilation


### PR DESCRIPTION
## Summary

Two fixes:

### 1. README: "two things" → "three things"
The intro listed three items but said "two things in one".

### 2. jdtls initialize timeout: 30s → 120s
jdtls was timing out during initialization on large Maven monorepos (e.g., `products` with hundreds of modules). The default `REQUEST_TIMEOUT = 30s` was used for the `initialize` handshake, but jdtls needs to scan pom.xml files, resolve classpaths, and build its index — easily exceeding 30s on large workspaces.

Added `INITIALIZE_TIMEOUT = 120s` used only for the `initialize` request. Normal request timeout stays at 30s.

**Why e2e tests didn't catch this:** Tests use a tiny single-file workspace (`Hello.java`) that initializes in <2s. The timeout only manifests on real-world monorepos.

## Test plan
- [x] All 336 tests pass, 84% coverage
- [ ] Manual: restart LSP in IntelliJ on products repo, verify jdtls initializes within 120s

🤖 Generated with [Claude Code](https://claude.com/claude-code)