### PR TITLE
fix: restore 120s timeout for jdtls initialize

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.7.4"
+version = "0.7.5"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -20,7 +20,8 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-REQUEST_TIMEOUT = 30.0  # seconds
+REQUEST_TIMEOUT = 30.0  # seconds — per-request timeout for normal operations
+_INITIALIZE_TIMEOUT = 120.0  # seconds — module-scoped init can still be slow (Maven classpath resolution)
 DEFAULT_JVM_MAX_HEAP = "4g"
 _STDERR_LINE_MAX = 1000
 
@@ -544,7 +545,7 @@ class JdtlsProxy:
             if self._process.stderr is not None:
                 self._stderr_task = asyncio.create_task(self._stderr_reader(self._process.stderr))
 
-            result = await self.send_request("initialize", effective_params)
+            result = await self.send_request("initialize", effective_params, timeout=_INITIALIZE_TIMEOUT)
             if result is None:
                 logger.error("jdtls initialize request failed or timed out")
                 await self.stop()


### PR DESCRIPTION
Even module-scoped init can take >30s when the module has heavy Maven dependencies.

One-line change: `send_request("initialize", ..., timeout=_INITIALIZE_TIMEOUT)` with `_INITIALIZE_TIMEOUT = 120s`. Normal request timeout stays at 30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)