### PR TITLE
fix: skip non-Java URIs in jdtls diagnostics callback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.7.5"
+version = "0.7.6"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -67,6 +67,8 @@ class JavaFunctionalLspServer(LanguageServer):
 
     def _on_jdtls_diagnostics(self, uri: str, diagnostics: list[Any]) -> None:
         """Called when jdtls publishes diagnostics — merge with custom and re-publish."""
+        if not uri.endswith(".java"):
+            return
         try:
             _analyze_and_publish(uri)
         except Exception as e:


### PR DESCRIPTION
## Summary
- Skip non-`.java` URIs in `_on_jdtls_diagnostics` to prevent `[Errno 21] Is a directory` errors
- jdtls publishes diagnostics for directory URIs and build config files during workspace init — our custom analysis only applies to Java files
- Works for both Maven and Gradle projects

## Test plan
- [x] All 361 tests pass
- [x] Pre-commit checks pass (lint, format, type check, coverage)
- [ ] Manual: open LSP against products repo, verify no directory errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)