### PR TITLE
fix: module-scoped data-dir to avoid loading stale monorepo index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.7.7"
+version = "0.7.8"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.7.7"
+__version__ = "0.7.8"

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -484,18 +484,22 @@ class JdtlsProxy:
         """Start jdtls subprocess and initialize it.
 
         If *module_root_uri* is provided, jdtls is scoped to that module for
-        fast startup. The data-directory hash is always based on the original
-        workspace root (from init_params) so the index persists across restarts.
+        fast startup and the data-dir hash is based on the module URI (so each
+        module gets its own isolated index). Otherwise the workspace root is used.
         """
         jdtls_path = shutil.which("jdtls")
         if not jdtls_path:
             return False
 
-        # Data-dir hash based on original workspace root (stable across module changes).
+        # Data-dir hash: use module URI when scoped so each module gets its own
+        # clean jdtls state. This avoids loading a 2.5GB monorepo index when only
+        # one module is needed. Without expansion, each session is module-scoped,
+        # so the data-dir should match that scope.
         original_root: str = init_params.get("rootUri") or init_params.get("rootPath") or str(Path.cwd())
         self._original_root_uri = original_root
-        workspace_hash = hashlib.sha256(original_root.encode()).hexdigest()[:12]
-        data_dir = Path.home() / ".cache" / "jdtls-data" / workspace_hash
+        hash_source = module_root_uri or original_root
+        data_hash = hashlib.sha256(hash_source.encode()).hexdigest()[:12]
+        data_dir = Path.home() / ".cache" / "jdtls-data" / data_hash
         data_dir.mkdir(parents=True, exist_ok=True)
 
         # Deep copy to avoid mutating server._init_params.


### PR DESCRIPTION
## Summary
- Use module URI (not workspace root) for jdtls data-dir hash when module-scoped
- Prevents loading 2.5GB stale monorepo index when only one module is needed
- Each module gets its own small data-dir (~10-50MB), enabling fast cold starts

## Context
PR #50 removed eager workspace expansion but jdtls initialize still timed out at 120s because the data-dir was shared across all sessions. The products monorepo data-dir had grown to 2.5GB from previous full-workspace sessions. Even scoped to one module, jdtls loaded the entire cached state.

## Test plan
- [x] All 361 tests pass
- [x] Pre-commit checks pass (lint, format, type check, coverage 84%)
- [ ] Manual: open Java file from products repo, verify initialize completes in <15s
- [ ] Manual: verify hover/definition on third-party types works

🤖 Generated with [Claude Code](https://claude.com/claude-code)