### PR TITLE
feat: add Lombok support with auto-discovery and false-positive filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,22 @@ public String legacyMethod() { ... }
 
 Works on classes, methods, constructors, fields, and local variables. Suppression applies to the annotated scope — a class-level annotation suppresses all methods within it.
 
+### Lombok support
+
+Projects using [Lombok](https://projectlombok.org/) need the Lombok Java agent for jdtls to process `@Builder`, `@Value`, `@Data`, `@Slf4j`, and other annotations. Without it, jdtls reports false "method undefined" errors for generated methods.
+
+The server auto-discovers `lombok.jar` from these locations (first match wins):
+
+1. **Project config** — add to `.java-functional-lsp.json`:
+   ```json
+   { "lombok": "/path/to/lombok.jar" }
+   ```
+2. **Environment variable** — `LOMBOK_JAR=/path/to/lombok.jar`
+3. **Maven cache** — auto-discovered from `~/.m2/repository/org/projectlombok/lombok/`
+4. **Dedicated directory** — `~/.jdtls-libs/lombok.jar`
+
+If Lombok is used in your project but the jar isn't found, the server automatically filters common Lombok false-positive errors (like "builder() is undefined") so they don't clutter your diagnostics.
+
 ## Code actions (quick fixes)
 
 The server provides LSP code actions (`textDocument/codeAction`) that automatically refactor code. When your editor shows a diagnostic with a lightbulb icon, clicking it applies the fix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.7.8"
+version = "0.7.9"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.7.8"
+__version__ = "0.7.9"

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -433,6 +433,58 @@ def _resolve_module_uri(file_uri: str) -> str | None:
     return module_uri or None
 
 
+def _version_key(name: str) -> tuple[int, ...]:
+    """Parse a version string into a tuple for semantic comparison."""
+    parts: list[int] = []
+    for segment in re.split(r"[.\-]", name):
+        try:
+            parts.append(int(segment))
+        except ValueError:
+            break
+    return tuple(parts)
+
+
+def _find_lombok_jar(config: Mapping[str, Any] | None = None) -> str | None:
+    """Find lombok.jar from configurable and auto-discovered locations.
+
+    Search order (first match wins):
+    1. Project config (.java-functional-lsp.json): ``{"lombok": "/path/to/lombok.jar"}``
+    2. Environment variable: ``LOMBOK_JAR``
+    3. Maven cache: ``~/.m2/repository/org/projectlombok/lombok/*/lombok-*.jar``
+    4. Dedicated directory: ``~/.jdtls-libs/lombok.jar``
+    """
+    # 1. Project config
+    if config and config.get("lombok"):
+        p = Path(config["lombok"]).expanduser()
+        if p.is_file():
+            return str(p)
+        logger.warning("Lombok path from config does not exist: %s", _redact_path(str(p)))
+
+    # 2. Environment variable
+    env_path = os.environ.get("LOMBOK_JAR")
+    if env_path:
+        p = Path(env_path).expanduser()
+        if p.is_file():
+            return str(p)
+        logger.warning("LOMBOK_JAR does not exist: %s", _redact_path(env_path))
+
+    # 3. Maven cache (latest version, semantic sort)
+    m2_lombok = Path.home() / ".m2" / "repository" / "org" / "projectlombok" / "lombok"
+    if m2_lombok.is_dir():
+        version_dirs = [d for d in m2_lombok.iterdir() if d.is_dir()]
+        for version_dir in sorted(version_dirs, key=lambda d: _version_key(d.name), reverse=True):
+            jar = version_dir / f"lombok-{version_dir.name}.jar"
+            if jar.is_file():
+                return str(jar)
+
+    # 4. Dedicated directory
+    fallback = Path.home() / ".jdtls-libs" / "lombok.jar"
+    if fallback.is_file():
+        return str(fallback)
+
+    return None
+
+
 class JdtlsProxy:
     """Manages a jdtls subprocess and provides async request/notification forwarding."""
 
@@ -457,6 +509,7 @@ class JdtlsProxy:
         self._original_root_uri: str | None = None
         self._initial_module_uri: str | None = None
         self.modules = ModuleRegistry()
+        self.has_lombok = False
         self._workspace_expanded = False
 
     @property
@@ -480,7 +533,13 @@ class JdtlsProxy:
             logger.warning("jdtls not found on PATH — running in standalone mode (custom rules only)")
         return self._jdtls_on_path
 
-    async def start(self, init_params: dict[str, Any], *, module_root_uri: str | None = None) -> bool:
+    async def start(
+        self,
+        init_params: dict[str, Any],
+        *,
+        module_root_uri: str | None = None,
+        config: Mapping[str, Any] | None = None,
+    ) -> bool:
         """Start jdtls subprocess and initialize it.
 
         If *module_root_uri* is provided, jdtls is scoped to that module for
@@ -525,16 +584,24 @@ class JdtlsProxy:
         self._initial_module_uri = module_root_uri
         self.modules.mark_added(effective_root_uri)
 
-        # Build a clean environment for jdtls.
+        # Build a clean environment and find Lombok jar (both do blocking I/O).
         loop = asyncio.get_running_loop()
-        jdtls_env = await loop.run_in_executor(None, build_jdtls_env)
+        jdtls_env, lombok_jar = await loop.run_in_executor(None, lambda: (build_jdtls_env(), _find_lombok_jar(config)))
+        if lombok_jar:
+            logger.info("jdtls: using Lombok agent from %s", _redact_path(lombok_jar))
+
+        jdtls_cmd: list[str] = [
+            jdtls_path,
+            "-data",
+            str(data_dir),
+            f"--jvm-arg=-Xmx{DEFAULT_JVM_MAX_HEAP}",
+        ]
+        if lombok_jar:
+            jdtls_cmd.append(f"--jvm-arg=-javaagent:{lombok_jar}")
 
         try:
             self._process = await asyncio.create_subprocess_exec(
-                jdtls_path,
-                "-data",
-                str(data_dir),
-                f"--jvm-arg=-Xmx{DEFAULT_JVM_MAX_HEAP}",
+                *jdtls_cmd,
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -563,13 +630,19 @@ class JdtlsProxy:
 
             await self.send_notification("initialized", {})
             self._available = True
+            self.has_lombok = lombok_jar is not None
             return True
 
         except (OSError, FileNotFoundError) as e:
             logger.error("Failed to start jdtls: %s", e)
             return False
 
-    async def ensure_started(self, init_params: dict[str, Any], file_uri: str) -> bool:
+    async def ensure_started(
+        self,
+        init_params: dict[str, Any],
+        file_uri: str,
+        config: Mapping[str, Any] | None = None,
+    ) -> bool:
         """Start jdtls lazily, scoped to the module containing *file_uri*.
 
         Thread-safe: uses asyncio.Lock to prevent double-start from rapid
@@ -596,7 +669,7 @@ class JdtlsProxy:
             self._starting = True
             try:
                 module_uri = _resolve_module_uri(file_uri)
-                started = await self.start(init_params, module_root_uri=module_uri)
+                started = await self.start(init_params, module_root_uri=module_uri, config=config)
                 if not started:
                     self._start_failed = True
                     self._start_failed_at = time.monotonic()

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -197,6 +198,28 @@ def _jdtls_raw_to_lsp_diagnostics(raw_diagnostics: list[Any]) -> list[lsp.Diagno
     return result
 
 
+# Lombok-specific patterns: only match diagnostics that are clearly Lombok-generated.
+# Intentionally narrow to avoid suppressing real compile errors.
+_LOMBOK_PATTERNS = re.compile(
+    r"(?:"
+    r"The method builder\(\)|"  # @Builder
+    r"The method toBuilder\(\)|"  # @Builder(toBuilder=true)
+    r"log cannot be resolved|"  # @Slf4j, @Log
+    r"\w+Builder cannot be resolved to a type|"  # @Builder inner class
+    r"The blank final field \w+ may not have been initialized"  # @Value final fields
+    r")"
+)
+
+
+def _is_lombok_false_positive(diag: dict[str, Any]) -> bool:
+    """Check if a jdtls diagnostic is likely a Lombok false positive.
+
+    Only matches narrow Lombok-specific patterns to avoid suppressing real errors.
+    """
+    msg = diag.get("message", "")
+    return bool(_LOMBOK_PATTERNS.search(msg))
+
+
 def _run_analysis(source: str, uri: str) -> list[lsp.Diagnostic]:
     """Run custom analyzers on source text and merge with jdtls diagnostics."""
     custom_diags = _analyze_document(source, uri)
@@ -204,6 +227,8 @@ def _run_analysis(source: str, uri: str) -> list[lsp.Diagnostic]:
     jdtls_diags: list[lsp.Diagnostic] = []
     if server._proxy.is_available:
         raw = server._proxy.get_cached_diagnostics(uri)
+        if not server._proxy.has_lombok:
+            raw = [d for d in raw if not _is_lombok_false_positive(d)]
         jdtls_diags = _jdtls_raw_to_lsp_diagnostics(raw)
 
     return jdtls_diags + custom_diags
@@ -419,7 +444,7 @@ async def _lazy_start_jdtls(file_uri: str) -> None:
     are loaded on-demand via ``add_module_if_new()`` as files are opened.
     """
     try:
-        started = await server._proxy.ensure_started(server._init_params, file_uri)
+        started = await server._proxy.ensure_started(server._init_params, file_uri, config=server._config)
         if started:
             logger.info("jdtls proxy active — full Java language support enabled")
             await _register_jdtls_capabilities()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1103,7 +1103,7 @@ class TestLazyStart:
         proxy._jdtls_on_path = True
         captured: dict[str, Any] = {}
 
-        async def capturing_start(params: Any, *, module_root_uri: str | None = None) -> bool:
+        async def capturing_start(params: Any, *, module_root_uri: str | None = None, config: Any = None) -> bool:
             captured["module_root_uri"] = module_root_uri
             return False
 
@@ -1127,7 +1127,7 @@ class TestLazyStart:
 
         captured: dict[str, Any] = {}
 
-        async def capturing_start(params: Any, *, module_root_uri: str | None = None) -> bool:
+        async def capturing_start(params: Any, *, module_root_uri: str | None = None, config: Any = None) -> bool:
             captured["module_root_uri"] = module_root_uri
             return False
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -642,6 +642,125 @@ class TestServerInternals:
 
 
 # --------------------------------------------------------------------------
+# --------------------------------------------------------------------------
+# Lombok support tests
+# --------------------------------------------------------------------------
+
+
+class TestLombokFalsePositive:
+    """Tests for _is_lombok_false_positive()."""
+
+    def test_matches_builder_undefined(self) -> None:
+        from java_functional_lsp.server import _is_lombok_false_positive
+
+        diag = {"code": "67108964", "message": "The method builder() is undefined for the type Foo"}
+        assert _is_lombok_false_positive(diag) is True
+
+    def test_matches_log_unresolved(self) -> None:
+        from java_functional_lsp.server import _is_lombok_false_positive
+
+        diag = {"code": "570425394", "message": "log cannot be resolved"}
+        assert _is_lombok_false_positive(diag) is True
+
+    def test_matches_builder_type_unresolved(self) -> None:
+        from java_functional_lsp.server import _is_lombok_false_positive
+
+        diag = {"code": "16777218", "message": "FooBuilder cannot be resolved to a type"}
+        assert _is_lombok_false_positive(diag) is True
+
+    def test_does_not_match_real_undefined_method(self) -> None:
+        from java_functional_lsp.server import _is_lombok_false_positive
+
+        diag = {"code": "67108964", "message": "The method foo() is undefined for the type String"}
+        assert _is_lombok_false_positive(diag) is False
+
+    def test_does_not_match_real_unresolved_type(self) -> None:
+        from java_functional_lsp.server import _is_lombok_false_positive
+
+        diag = {"code": "16777218", "message": "SomeClass cannot be resolved to a type"}
+        assert _is_lombok_false_positive(diag) is False
+
+    def test_empty_message(self) -> None:
+        from java_functional_lsp.server import _is_lombok_false_positive
+
+        diag = {"code": "67108964", "message": ""}
+        assert _is_lombok_false_positive(diag) is False
+
+    def test_missing_fields(self) -> None:
+        from java_functional_lsp.server import _is_lombok_false_positive
+
+        assert _is_lombok_false_positive({}) is False
+
+    def test_matches_blank_final_field(self) -> None:
+        from java_functional_lsp.server import _is_lombok_false_positive
+
+        diag = {"code": "33554513", "message": "The blank final field name may not have been initialized"}
+        assert _is_lombok_false_positive(diag) is True
+
+
+class TestFindLombokJar:
+    """Tests for _find_lombok_jar()."""
+
+    def test_config_path_wins(self, tmp_path: Any) -> None:
+        from java_functional_lsp.proxy import _find_lombok_jar
+
+        jar = tmp_path / "lombok.jar"
+        jar.touch()
+        result = _find_lombok_jar({"lombok": str(jar)})
+        assert result == str(jar)
+
+    def test_env_var_used(self, tmp_path: Any, monkeypatch: Any) -> None:
+        from java_functional_lsp.proxy import _find_lombok_jar
+
+        jar = tmp_path / "lombok.jar"
+        jar.touch()
+        monkeypatch.setenv("LOMBOK_JAR", str(jar))
+        result = _find_lombok_jar()
+        assert result == str(jar)
+
+    def test_config_wins_over_env(self, tmp_path: Any, monkeypatch: Any) -> None:
+        from java_functional_lsp.proxy import _find_lombok_jar
+
+        config_jar = tmp_path / "config-lombok.jar"
+        config_jar.touch()
+        env_jar = tmp_path / "env-lombok.jar"
+        env_jar.touch()
+        monkeypatch.setenv("LOMBOK_JAR", str(env_jar))
+        result = _find_lombok_jar({"lombok": str(config_jar)})
+        assert result == str(config_jar)
+
+    def test_maven_cache_semantic_sort(self, tmp_path: Any, monkeypatch: Any) -> None:
+        from java_functional_lsp.proxy import _find_lombok_jar
+
+        monkeypatch.delenv("LOMBOK_JAR", raising=False)
+        m2 = tmp_path / ".m2" / "repository" / "org" / "projectlombok" / "lombok"
+        for v in ["1.18.4", "1.18.30", "1.9.2"]:
+            d = m2 / v
+            d.mkdir(parents=True)
+            (d / f"lombok-{v}.jar").touch()
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        result = _find_lombok_jar()
+        assert result is not None
+        assert "1.18.30" in result  # Semantic sort picks 1.18.30 over 1.9.2
+
+    def test_returns_none_when_nothing_found(self, tmp_path: Any, monkeypatch: Any) -> None:
+        from java_functional_lsp.proxy import _find_lombok_jar
+
+        monkeypatch.delenv("LOMBOK_JAR", raising=False)
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        result = _find_lombok_jar()
+        assert result is None
+
+    def test_warns_on_missing_config_path(self, tmp_path: Any, caplog: Any) -> None:
+        import logging
+
+        from java_functional_lsp.proxy import _find_lombok_jar
+
+        with caplog.at_level(logging.WARNING, logger="java_functional_lsp.proxy"):
+            _find_lombok_jar({"lombok": "/nonexistent/lombok.jar"})
+        assert any("does not exist" in r.getMessage() for r in caplog.records)
+
+
 # Subprocess-based tests — zero mocks, real LSP transport
 # --------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.7.4"
+version = "0.7.9"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary
- Auto-discover Lombok agent from 4 configurable locations (project config, env var, Maven cache, dedicated dir)
- Pass Lombok agent as `-javaagent` to jdtls for proper annotation processing
- When agent is not found, filter common Lombok false-positive diagnostics so red marks don't drown custom hints
- Document all Lombok config methods in README

## Context
After PRs #49-51 fixed the jdtls timeout, diagnostics flow correctly but projects using Lombok show hundreds of false "method undefined" errors because jdtls doesn't process Lombok annotations without the agent.

## Test plan
- [x] All 361 tests pass
- [x] Pre-commit checks pass (lint, format, type check, coverage 83%)
- [ ] Manual: verify Lombok agent found from Maven cache
- [ ] Manual: verify no red marks for Lombok-generated methods
- [ ] Manual: verify false-positive filter works when agent is not available

🤖 Generated with [Claude Code](https://claude.com/claude-code)