### PR TITLE
fix: isolate jdtls failures from custom diagnostics + invalidate stale data-dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,13 +240,11 @@ The server auto-discovers `lombok.jar` from these locations (first match wins):
 3. **Maven cache** — auto-discovered from `~/.m2/repository/org/projectlombok/lombok/`
 4. **Dedicated directory** — `~/.jdtls-libs/lombok.jar`
 
-If Lombok is used in your project but the jar isn't found, the server automatically filters common Lombok false-positive errors (like "builder() is undefined") so they don't clutter your diagnostics.
+If Lombok is used in your project but the jar isn't found, the server logs a warning. The jdtls cache is automatically cleared on version upgrade, so adding Lombok support takes effect immediately after `brew upgrade`.
 
-### Suppressing jdtls false positives
+### Suppressing jdtls diagnostics
 
-In large monorepos, jdtls may report false "method undefined" errors for Lombok-generated methods (e.g., `@Value(staticConstructor = "of")`) in modules it hasn't fully indexed. The server automatically filters common Lombok patterns (`builder()`, `toBuilder()`, `of()`, `create()`, `log`, `*Builder` types, blank final fields).
-
-For project-specific patterns (e.g., MapStruct mappers, other annotation processors), use `suppressJdtlsPatterns` to add custom regex filters:
+For project-specific jdtls false positives (e.g., annotation processor methods, MapStruct mappers), use `suppressJdtlsPatterns` to add custom regex filters:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Create `.java-functional-lsp.json` in your project root to customize rules:
 **Options:**
 - `excludes` — glob patterns for files/directories to skip entirely (supports `**` for multi-segment wildcards)
 - `rules` — per-rule severity: `error`, `warning` (default), `info`, `hint`, `off`
+- `suppressJdtlsPatterns` — list of regex patterns to suppress jdtls diagnostics (see below)
 
 **Spring-aware behavior:**
 - `throw-statement`, `catch-rethrow`, and `try-catch-to-monadic` are automatically suppressed inside `@Bean` methods
@@ -240,6 +241,23 @@ The server auto-discovers `lombok.jar` from these locations (first match wins):
 4. **Dedicated directory** — `~/.jdtls-libs/lombok.jar`
 
 If Lombok is used in your project but the jar isn't found, the server automatically filters common Lombok false-positive errors (like "builder() is undefined") so they don't clutter your diagnostics.
+
+### Suppressing jdtls false positives
+
+In large monorepos, jdtls may report false "method undefined" errors for Lombok-generated methods (e.g., `@Value(staticConstructor = "of")`) in modules it hasn't fully indexed. The server automatically filters common Lombok patterns (`builder()`, `toBuilder()`, `of()`, `create()`, `log`, `*Builder` types, blank final fields).
+
+For project-specific patterns (e.g., MapStruct mappers, other annotation processors), use `suppressJdtlsPatterns` to add custom regex filters:
+
+```json
+{
+  "suppressJdtlsPatterns": [
+    "The method \\w+Mapper\\(\\) is undefined",
+    "cannot be resolved to a type"
+  ]
+}
+```
+
+Each entry is a regex matched against jdtls diagnostic messages. Invalid patterns are skipped with a warning.
 
 ## Code actions (quick fixes)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.7.9"
+version = "0.8.0"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.7.9"
+__version__ = "0.8.0"

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -444,6 +444,29 @@ def _version_key(name: str) -> tuple[int, ...]:
     return tuple(parts)
 
 
+def _clear_cache_on_version_change(cache_root: Path) -> None:
+    """Clear jdtls data cache when the server version changes.
+
+    Stores a ``.version`` marker in the cache root. On version mismatch
+    (e.g., Lombok agent added, jdtls config changed), wipes the entire
+    cache so jdtls re-indexes from scratch with the current configuration.
+    """
+    from . import __version__
+
+    marker = cache_root / ".version"
+    try:
+        if marker.exists() and marker.read_text().strip() == __version__:
+            return
+        # Version changed or first run — clear stale caches.
+        if cache_root.exists():
+            shutil.rmtree(cache_root)
+            logger.info("jdtls: cleared stale cache (version changed to %s)", __version__)
+        cache_root.mkdir(parents=True, exist_ok=True)
+        marker.write_text(__version__)
+    except OSError as e:
+        logger.warning("jdtls: failed to manage cache version marker: %s", e)
+
+
 def _find_lombok_jar(config: Mapping[str, Any] | None = None) -> str | None:
     """Find lombok.jar from configurable and auto-discovered locations.
 
@@ -553,21 +576,21 @@ class JdtlsProxy:
         original_root: str = init_params.get("rootUri") or init_params.get("rootPath") or str(Path.cwd())
         self._original_root_uri = original_root
 
-        # Discover Lombok jar and build jdtls env BEFORE computing the data-dir
-        # hash, so that adding/changing the Lombok agent invalidates stale indexes.
+        # Discover Lombok jar and build jdtls env (blocking I/O in executor).
         loop = asyncio.get_running_loop()
         jdtls_env, lombok_jar = await loop.run_in_executor(None, lambda: (build_jdtls_env(), _find_lombok_jar(config)))
         if lombok_jar:
             logger.info("jdtls: using Lombok agent from %s", _redact_path(lombok_jar))
 
-        # Data-dir hash: includes module URI + Lombok jar path so that changing
-        # either gives jdtls a fresh index (avoids stale caches that cause
-        # AssertionFailedExceptions and silently break annotation processing).
+        # Clear stale jdtls caches when the server version changes (e.g.,
+        # Lombok agent added, jdtls config changed). A version marker file
+        # tracks this — mismatch wipes the whole cache for a clean reindex.
+        cache_root = Path.home() / ".cache" / "jdtls-data"
+        _clear_cache_on_version_change(cache_root)
+
         hash_source = module_root_uri or original_root
-        if lombok_jar:
-            hash_source += f"|lombok={lombok_jar}"
         data_hash = hashlib.sha256(hash_source.encode()).hexdigest()[:12]
-        data_dir = Path.home() / ".cache" / "jdtls-data" / data_hash
+        data_dir = cache_root / data_hash
         data_dir.mkdir(parents=True, exist_ok=True)
 
         # Deep copy to avoid mutating server._init_params.

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -575,18 +575,25 @@ class JdtlsProxy:
 
         original_root: str = init_params.get("rootUri") or init_params.get("rootPath") or str(Path.cwd())
         self._original_root_uri = original_root
+        effective_root_uri = module_root_uri or original_root
 
-        # Discover Lombok jar and build jdtls env (blocking I/O in executor).
+        # Mark ADDED before any await to prevent duplicate module additions
+        # from concurrent coroutines during the executor yield below.
+        self._initial_module_uri = module_root_uri
+        self.modules.mark_added(effective_root_uri)
+
+        # All blocking startup I/O in a single executor call: cache version check
+        # (may rmtree on upgrade), Lombok discovery, and jdtls env build.
+        cache_root = Path.home() / ".cache" / "jdtls-data"
+
+        def _blocking_startup() -> tuple[dict[str, str], str | None]:
+            _clear_cache_on_version_change(cache_root)
+            return build_jdtls_env(), _find_lombok_jar(config)
+
         loop = asyncio.get_running_loop()
-        jdtls_env, lombok_jar = await loop.run_in_executor(None, lambda: (build_jdtls_env(), _find_lombok_jar(config)))
+        jdtls_env, lombok_jar = await loop.run_in_executor(None, _blocking_startup)
         if lombok_jar:
             logger.info("jdtls: using Lombok agent from %s", _redact_path(lombok_jar))
-
-        # Clear stale jdtls caches when the server version changes (e.g.,
-        # Lombok agent added, jdtls config changed). A version marker file
-        # tracks this — mismatch wipes the whole cache for a clean reindex.
-        cache_root = Path.home() / ".cache" / "jdtls-data"
-        _clear_cache_on_version_change(cache_root)
 
         hash_source = module_root_uri or original_root
         data_hash = hashlib.sha256(hash_source.encode()).hexdigest()[:12]
@@ -595,7 +602,6 @@ class JdtlsProxy:
 
         # Deep copy to avoid mutating server._init_params.
         effective_params = copy.deepcopy(init_params)
-        effective_root_uri = module_root_uri or original_root
         if module_root_uri:
             effective_params["rootUri"] = module_root_uri
             from pygls.uris import to_fs_path
@@ -611,10 +617,6 @@ class JdtlsProxy:
         caps = effective_params.setdefault("capabilities", {})
         ws = caps.setdefault("workspace", {})
         ws["workspaceFolders"] = True
-
-        # Track the initial module as already loaded.
-        self._initial_module_uri = module_root_uri
-        self.modules.mark_added(effective_root_uri)
 
         jdtls_cmd: list[str] = [
             jdtls_path,

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -550,13 +550,22 @@ class JdtlsProxy:
         if not jdtls_path:
             return False
 
-        # Data-dir hash: use module URI when scoped so each module gets its own
-        # clean jdtls state. This avoids loading a 2.5GB monorepo index when only
-        # one module is needed. Without expansion, each session is module-scoped,
-        # so the data-dir should match that scope.
         original_root: str = init_params.get("rootUri") or init_params.get("rootPath") or str(Path.cwd())
         self._original_root_uri = original_root
+
+        # Discover Lombok jar and build jdtls env BEFORE computing the data-dir
+        # hash, so that adding/changing the Lombok agent invalidates stale indexes.
+        loop = asyncio.get_running_loop()
+        jdtls_env, lombok_jar = await loop.run_in_executor(None, lambda: (build_jdtls_env(), _find_lombok_jar(config)))
+        if lombok_jar:
+            logger.info("jdtls: using Lombok agent from %s", _redact_path(lombok_jar))
+
+        # Data-dir hash: includes module URI + Lombok jar path so that changing
+        # either gives jdtls a fresh index (avoids stale caches that cause
+        # AssertionFailedExceptions and silently break annotation processing).
         hash_source = module_root_uri or original_root
+        if lombok_jar:
+            hash_source += f"|lombok={lombok_jar}"
         data_hash = hashlib.sha256(hash_source.encode()).hexdigest()[:12]
         data_dir = Path.home() / ".cache" / "jdtls-data" / data_hash
         data_dir.mkdir(parents=True, exist_ok=True)
@@ -583,12 +592,6 @@ class JdtlsProxy:
         # Track the initial module as already loaded (mark ADDED before await).
         self._initial_module_uri = module_root_uri
         self.modules.mark_added(effective_root_uri)
-
-        # Build a clean environment and find Lombok jar (both do blocking I/O).
-        loop = asyncio.get_running_loop()
-        jdtls_env, lombok_jar = await loop.run_in_executor(None, lambda: (build_jdtls_env(), _find_lombok_jar(config)))
-        if lombok_jar:
-            logger.info("jdtls: using Lombok agent from %s", _redact_path(lombok_jar))
 
         jdtls_cmd: list[str] = [
             jdtls_path,

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -589,7 +589,7 @@ class JdtlsProxy:
         ws = caps.setdefault("workspace", {})
         ws["workspaceFolders"] = True
 
-        # Track the initial module as already loaded (mark ADDED before await).
+        # Track the initial module as already loaded.
         self._initial_module_uri = module_root_uri
         self.modules.mark_added(effective_root_uri)
 

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -198,38 +198,74 @@ def _jdtls_raw_to_lsp_diagnostics(raw_diagnostics: list[Any]) -> list[lsp.Diagno
     return result
 
 
-# Lombok-specific patterns: only match diagnostics that are clearly Lombok-generated.
-# Intentionally narrow to avoid suppressing real compile errors.
-_LOMBOK_PATTERNS = re.compile(
+# Built-in patterns for Lombok annotation-processor false positives.
+# Always applied — when the Lombok agent IS loaded and working, these methods
+# resolve correctly so the patterns simply never match. When the agent isn't
+# loaded (or only covers the initial module), these suppress the noise.
+_BUILTIN_AP_PATTERNS = re.compile(
     r"(?:"
     r"The method builder\(\)|"  # @Builder
     r"The method toBuilder\(\)|"  # @Builder(toBuilder=true)
+    r"The method of\(\)|"  # @Value(staticConstructor = "of")
+    r"The method create\(\)|"  # @Value(staticConstructor = "create")
     r"log cannot be resolved|"  # @Slf4j, @Log
     r"\w+Builder cannot be resolved to a type|"  # @Builder inner class
     r"The blank final field \w+ may not have been initialized"  # @Value final fields
     r")"
 )
 
+# Compiled user-defined patterns (populated from config on initialize)
+_user_suppress_patterns: list[re.Pattern[str]] = []
 
-def _is_lombok_false_positive(diag: dict[str, Any]) -> bool:
-    """Check if a jdtls diagnostic is likely a Lombok false positive.
 
-    Only matches narrow Lombok-specific patterns to avoid suppressing real errors.
+def _compile_user_patterns(config: dict[str, Any]) -> list[re.Pattern[str]]:
+    """Compile user-defined suppressJdtlsPatterns from config."""
+    raw = config.get("suppressJdtlsPatterns", [])
+    if not isinstance(raw, list):
+        logger.warning("suppressJdtlsPatterns must be a list of regex strings, got %s", type(raw).__name__)
+        return []
+    patterns: list[re.Pattern[str]] = []
+    for entry in raw:
+        if not isinstance(entry, str):
+            continue
+        try:
+            patterns.append(re.compile(entry))
+        except re.error as e:
+            logger.warning("Invalid suppressJdtlsPatterns regex %r: %s", entry, e)
+    return patterns
+
+
+def _is_jdtls_false_positive(diag: dict[str, Any]) -> bool:
+    """Check if a jdtls diagnostic is a known annotation-processor false positive.
+
+    Matches built-in Lombok patterns and any user-configured suppressJdtlsPatterns.
+    Always safe to apply: when the Lombok agent is loaded, Lombok-generated methods
+    resolve correctly so built-in patterns simply never match.
     """
     msg = diag.get("message", "")
-    return bool(_LOMBOK_PATTERNS.search(msg))
+    if _BUILTIN_AP_PATTERNS.search(msg):
+        return True
+    for pat in _user_suppress_patterns:
+        if pat.search(msg):
+            return True
+    return False
 
 
 def _run_analysis(source: str, uri: str) -> list[lsp.Diagnostic]:
-    """Run custom analyzers on source text and merge with jdtls diagnostics."""
+    """Run custom analyzers on source text and merge with jdtls diagnostics.
+
+    jdtls processing is isolated: if it fails, custom diagnostics still publish.
+    """
     custom_diags = _analyze_document(source, uri)
 
     jdtls_diags: list[lsp.Diagnostic] = []
     if server._proxy.is_available:
-        raw = server._proxy.get_cached_diagnostics(uri)
-        if not server._proxy.has_lombok:
-            raw = [d for d in raw if not _is_lombok_false_positive(d)]
-        jdtls_diags = _jdtls_raw_to_lsp_diagnostics(raw)
+        try:
+            raw = server._proxy.get_cached_diagnostics(uri)
+            raw = [d for d in raw if not _is_jdtls_false_positive(d)]
+            jdtls_diags = _jdtls_raw_to_lsp_diagnostics(raw)
+        except Exception as e:
+            logger.warning("jdtls diagnostic processing failed for %s: %s", uri, e)
 
     return jdtls_diags + custom_diags
 
@@ -257,6 +293,9 @@ def on_initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
         root = params.root_path
 
     server._config = _load_config(root)
+
+    global _user_suppress_patterns
+    _user_suppress_patterns = _compile_user_patterns(server._config)
 
     return lsp.InitializeResult(
         capabilities=lsp.ServerCapabilities(
@@ -363,7 +402,10 @@ def _analyze_and_publish(uri: str) -> None:
 async def _deferred_validate(uri: str) -> None:
     """Debounced validation — waits before analyzing to batch rapid edits."""
     await asyncio.sleep(_DEBOUNCE_SECONDS)
-    _analyze_and_publish(uri)
+    try:
+        _analyze_and_publish(uri)
+    except Exception as e:
+        logger.error("Validation failed for %s: %s", uri, e)
 
 
 def _forward_or_queue(method: str, serialized: Any) -> None:
@@ -402,7 +444,10 @@ async def on_did_open(params: lsp.DidOpenTextDocumentParams) -> None:
             task.add_done_callback(_bg_tasks.discard)
 
     # Custom diagnostics always publish immediately — never blocked by jdtls.
-    _analyze_and_publish(uri)
+    try:
+        _analyze_and_publish(uri)
+    except Exception as e:
+        logger.error("Analysis failed on open for %s: %s", uri, e)
 
 
 @server.feature(lsp.TEXT_DOCUMENT_DID_CHANGE)
@@ -420,7 +465,10 @@ async def on_did_change(params: lsp.DidChangeTextDocumentParams) -> None:
 async def on_did_save(params: lsp.DidSaveTextDocumentParams) -> None:
     """Forward to jdtls and re-analyze immediately (no debounce on save)."""
     _forward_or_queue("textDocument/didSave", _serialize_params(params))
-    _analyze_and_publish(params.text_document.uri)
+    try:
+        _analyze_and_publish(params.text_document.uri)
+    except Exception as e:
+        logger.error("Analysis failed on save for %s: %s", params.text_document.uri, e)
 
 
 @server.feature(lsp.TEXT_DOCUMENT_DID_CLOSE)

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -199,23 +199,6 @@ def _jdtls_raw_to_lsp_diagnostics(raw_diagnostics: list[Any]) -> list[lsp.Diagno
     return result
 
 
-# Built-in patterns for Lombok annotation-processor false positives.
-# Always applied — when the Lombok agent IS loaded and working, these methods
-# resolve correctly so the patterns simply never match. When the agent isn't
-# loaded (or only covers the initial module), these suppress the noise.
-_BUILTIN_AP_PATTERNS = re.compile(
-    r"(?:"
-    r"The method builder\(\) is undefined|"  # @Builder
-    r"The method toBuilder\(\) is undefined|"  # @Builder(toBuilder=true)
-    r"The method of\(\) is undefined|"  # @Value(staticConstructor = "of")
-    r"The method create\(\) is undefined|"  # @Value(staticConstructor = "create")
-    r"log cannot be resolved|"  # @Slf4j, @Log
-    r"\w+Builder cannot be resolved to a type|"  # @Builder inner class
-    r"The blank final field \w+ may not have been initialized"  # @Value final fields
-    r")"
-)
-
-
 def _compile_user_patterns(config: dict[str, Any]) -> list[re.Pattern[str]]:
     """Compile user-defined suppressJdtlsPatterns from config."""
     raw = config.get("suppressJdtlsPatterns", [])
@@ -233,16 +216,16 @@ def _compile_user_patterns(config: dict[str, Any]) -> list[re.Pattern[str]]:
     return patterns
 
 
-def _is_jdtls_false_positive(diag: dict[str, Any], user_patterns: list[re.Pattern[str]]) -> bool:
-    """Check if a jdtls diagnostic is a known annotation-processor false positive.
+def _is_jdtls_suppressed(diag: dict[str, Any], user_patterns: list[re.Pattern[str]]) -> bool:
+    """Check if a jdtls diagnostic matches a user-configured suppress pattern.
 
-    Matches built-in Lombok patterns and any user-configured suppressJdtlsPatterns.
-    Always safe to apply: when the Lombok agent is loaded, Lombok-generated methods
-    resolve correctly so built-in patterns simply never match.
+    No built-in patterns — the root cause (stale jdtls caches) is fixed by
+    clearing the cache on version change. Users can still suppress specific
+    jdtls messages via suppressJdtlsPatterns in .java-functional-lsp.json.
     """
+    if not user_patterns:
+        return False
     msg = diag.get("message", "")
-    if _BUILTIN_AP_PATTERNS.search(msg):
-        return True
     for pat in user_patterns:
         if pat.search(msg):
             return True
@@ -260,7 +243,7 @@ def _run_analysis(source: str, uri: str) -> list[lsp.Diagnostic]:
     if server._proxy.is_available:
         try:
             raw = server._proxy.get_cached_diagnostics(uri)
-            raw = [d for d in raw if not _is_jdtls_false_positive(d, server._user_suppress_patterns)]
+            raw = [d for d in raw if not _is_jdtls_suppressed(d, server._user_suppress_patterns)]
             jdtls_diags = _jdtls_raw_to_lsp_diagnostics(raw)
         except Exception as e:
             logger.warning("jdtls diagnostic processing failed for %s: %s", uri, e)

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -65,6 +65,7 @@ class JavaFunctionalLspServer(LanguageServer):
         self._config: dict[str, Any] = {}
         self._init_params: dict[str, Any] = {}
         self._proxy = JdtlsProxy(on_diagnostics=self._on_jdtls_diagnostics)
+        self._user_suppress_patterns: list[re.Pattern[str]] = []
 
     def _on_jdtls_diagnostics(self, uri: str, diagnostics: list[Any]) -> None:
         """Called when jdtls publishes diagnostics — merge with custom and re-publish.
@@ -204,18 +205,15 @@ def _jdtls_raw_to_lsp_diagnostics(raw_diagnostics: list[Any]) -> list[lsp.Diagno
 # loaded (or only covers the initial module), these suppress the noise.
 _BUILTIN_AP_PATTERNS = re.compile(
     r"(?:"
-    r"The method builder\(\)|"  # @Builder
-    r"The method toBuilder\(\)|"  # @Builder(toBuilder=true)
-    r"The method of\(\)|"  # @Value(staticConstructor = "of")
-    r"The method create\(\)|"  # @Value(staticConstructor = "create")
+    r"The method builder\(\) is undefined|"  # @Builder
+    r"The method toBuilder\(\) is undefined|"  # @Builder(toBuilder=true)
+    r"The method of\(\) is undefined|"  # @Value(staticConstructor = "of")
+    r"The method create\(\) is undefined|"  # @Value(staticConstructor = "create")
     r"log cannot be resolved|"  # @Slf4j, @Log
     r"\w+Builder cannot be resolved to a type|"  # @Builder inner class
     r"The blank final field \w+ may not have been initialized"  # @Value final fields
     r")"
 )
-
-# Compiled user-defined patterns (populated from config on initialize)
-_user_suppress_patterns: list[re.Pattern[str]] = []
 
 
 def _compile_user_patterns(config: dict[str, Any]) -> list[re.Pattern[str]]:
@@ -235,7 +233,7 @@ def _compile_user_patterns(config: dict[str, Any]) -> list[re.Pattern[str]]:
     return patterns
 
 
-def _is_jdtls_false_positive(diag: dict[str, Any]) -> bool:
+def _is_jdtls_false_positive(diag: dict[str, Any], user_patterns: list[re.Pattern[str]]) -> bool:
     """Check if a jdtls diagnostic is a known annotation-processor false positive.
 
     Matches built-in Lombok patterns and any user-configured suppressJdtlsPatterns.
@@ -245,7 +243,7 @@ def _is_jdtls_false_positive(diag: dict[str, Any]) -> bool:
     msg = diag.get("message", "")
     if _BUILTIN_AP_PATTERNS.search(msg):
         return True
-    for pat in _user_suppress_patterns:
+    for pat in user_patterns:
         if pat.search(msg):
             return True
     return False
@@ -262,7 +260,7 @@ def _run_analysis(source: str, uri: str) -> list[lsp.Diagnostic]:
     if server._proxy.is_available:
         try:
             raw = server._proxy.get_cached_diagnostics(uri)
-            raw = [d for d in raw if not _is_jdtls_false_positive(d)]
+            raw = [d for d in raw if not _is_jdtls_false_positive(d, server._user_suppress_patterns)]
             jdtls_diags = _jdtls_raw_to_lsp_diagnostics(raw)
         except Exception as e:
             logger.warning("jdtls diagnostic processing failed for %s: %s", uri, e)
@@ -293,9 +291,7 @@ def on_initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
         root = params.root_path
 
     server._config = _load_config(root)
-
-    global _user_suppress_patterns
-    _user_suppress_patterns = _compile_user_patterns(server._config)
+    server._user_suppress_patterns = _compile_user_patterns(server._config)
 
     return lsp.InitializeResult(
         capabilities=lsp.ServerCapabilities(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -654,98 +654,100 @@ class TestJdtlsFalsePositive:
         from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "67108964", "message": "The method builder() is undefined for the type Foo"}
-        assert _is_jdtls_false_positive(diag) is True
+        assert _is_jdtls_false_positive(diag, []) is True
 
     def test_matches_log_unresolved(self) -> None:
         from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "570425394", "message": "log cannot be resolved"}
-        assert _is_jdtls_false_positive(diag) is True
+        assert _is_jdtls_false_positive(diag, []) is True
 
     def test_matches_builder_type_unresolved(self) -> None:
         from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "16777218", "message": "FooBuilder cannot be resolved to a type"}
-        assert _is_jdtls_false_positive(diag) is True
+        assert _is_jdtls_false_positive(diag, []) is True
 
     def test_does_not_match_real_undefined_method(self) -> None:
         from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "67108964", "message": "The method foo() is undefined for the type String"}
-        assert _is_jdtls_false_positive(diag) is False
+        assert _is_jdtls_false_positive(diag, []) is False
 
     def test_does_not_match_real_unresolved_type(self) -> None:
         from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "16777218", "message": "SomeClass cannot be resolved to a type"}
-        assert _is_jdtls_false_positive(diag) is False
+        assert _is_jdtls_false_positive(diag, []) is False
 
     def test_empty_message(self) -> None:
         from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "67108964", "message": ""}
-        assert _is_jdtls_false_positive(diag) is False
+        assert _is_jdtls_false_positive(diag, []) is False
 
     def test_missing_fields(self) -> None:
         from java_functional_lsp.server import _is_jdtls_false_positive
 
-        assert _is_jdtls_false_positive({}) is False
+        assert _is_jdtls_false_positive({}, []) is False
 
     def test_matches_blank_final_field(self) -> None:
         from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "33554513", "message": "The blank final field name may not have been initialized"}
-        assert _is_jdtls_false_positive(diag) is True
+        assert _is_jdtls_false_positive(diag, []) is True
 
     def test_matches_static_constructor_of(self) -> None:
         from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "67108964", "message": "The method of() is undefined for the type ExternalFailureError"}
-        assert _is_jdtls_false_positive(diag) is True
+        assert _is_jdtls_false_positive(diag, []) is True
 
     def test_matches_static_constructor_create(self) -> None:
         from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "67108964", "message": "The method create() is undefined for the type Config"}
-        assert _is_jdtls_false_positive(diag) is True
+        assert _is_jdtls_false_positive(diag, []) is True
+
+    def test_does_not_match_of_without_undefined(self) -> None:
+        """Ensure 'of()' only matches in 'is undefined' context, not arbitrary messages."""
+        from java_functional_lsp.server import _is_jdtls_false_positive
+
+        diag = {"message": "The method of() has wrong return type"}
+        assert _is_jdtls_false_positive(diag, []) is False
 
 
 class TestUserSuppressPatterns:
     """Tests for configurable suppressJdtlsPatterns."""
 
     def test_user_pattern_matches(self) -> None:
-        import java_functional_lsp.server as srv
+        """User pattern matches a message NOT covered by built-in patterns."""
         from java_functional_lsp.server import _compile_user_patterns, _is_jdtls_false_positive
 
-        old = srv._user_suppress_patterns
-        try:
-            srv._user_suppress_patterns = _compile_user_patterns(
-                {"suppressJdtlsPatterns": [r"The method \w+\(\) is undefined for the type \w+Error"]}
-            )
-            diag = {"message": "The method of() is undefined for the type SearchEngineError"}
-            assert _is_jdtls_false_positive(diag) is True
-        finally:
-            srv._user_suppress_patterns = old
+        patterns = _compile_user_patterns({"suppressJdtlsPatterns": [r"The method generateReport\(\) is undefined"]})
+        diag = {"message": "The method generateReport() is undefined for the type InternalService"}
+        assert _is_jdtls_false_positive(diag, patterns) is True
 
     def test_user_pattern_does_not_match_unrelated(self) -> None:
-        import java_functional_lsp.server as srv
         from java_functional_lsp.server import _compile_user_patterns, _is_jdtls_false_positive
 
-        old = srv._user_suppress_patterns
-        try:
-            srv._user_suppress_patterns = _compile_user_patterns(
-                {"suppressJdtlsPatterns": [r"The method \w+\(\) is undefined for the type \w+Error"]}
-            )
-            diag = {"message": "The method foo() is undefined for the type String"}
-            assert _is_jdtls_false_positive(diag) is False
-        finally:
-            srv._user_suppress_patterns = old
+        patterns = _compile_user_patterns({"suppressJdtlsPatterns": [r"The method generateReport\(\) is undefined"]})
+        diag = {"message": "The method foo() is undefined for the type String"}
+        assert _is_jdtls_false_positive(diag, patterns) is False
+
+    def test_user_pattern_without_builtins(self) -> None:
+        """With empty user patterns and a non-Lombok message, returns False."""
+        from java_functional_lsp.server import _is_jdtls_false_positive
+
+        diag = {"message": "The method generateReport() is undefined for the type InternalService"}
+        assert _is_jdtls_false_positive(diag, []) is False
 
     def test_invalid_regex_skipped(self) -> None:
         from java_functional_lsp.server import _compile_user_patterns
 
         patterns = _compile_user_patterns({"suppressJdtlsPatterns": [r"valid", r"[invalid"]})
         assert len(patterns) == 1
+        assert patterns[0].search("valid") is not None
 
     def test_non_list_ignored(self) -> None:
         from java_functional_lsp.server import _compile_user_patterns
@@ -771,16 +773,15 @@ class TestJdtlsIsolation:
 
         java_source = "public class Foo { public String bar() { return null; } }"
 
-        # Simulate jdtls being available but get_cached_diagnostics throwing
         with patch("java_functional_lsp.server.server") as mock_server:
             mock_server._proxy.is_available = True
             mock_server._proxy.get_cached_diagnostics.side_effect = RuntimeError("jdtls corrupt")
+            mock_server._user_suppress_patterns = []
             mock_server._config = {}
             mock_server._parser = __import__("java_functional_lsp.analyzers.base", fromlist=["get_parser"]).get_parser()
 
             result = _run_analysis(java_source, "file:///test/Foo.java")
 
-        # Custom diagnostics should still be present (null-return rule)
         custom_diags = [d for d in result if d.source == "java-functional-lsp"]
         assert len(custom_diags) > 0, "Custom diagnostics should publish even when jdtls fails"
 
@@ -801,6 +802,23 @@ class TestJdtlsIsolation:
 
         custom_diags = [d for d in result if d.source == "java-functional-lsp"]
         assert len(custom_diags) > 0, "Custom diagnostics should publish without jdtls"
+
+    def test_analyze_and_publish_exception_does_not_crash_handler(self) -> None:
+        """Handler-level try/except prevents server crash when _analyze_and_publish raises."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import _deferred_validate
+
+        with patch("java_functional_lsp.server._analyze_and_publish", side_effect=RuntimeError("boom")):
+            import asyncio
+
+            loop = asyncio.new_event_loop()
+            try:
+                # _deferred_validate should catch the exception and log, not raise
+                loop.run_until_complete(_deferred_validate("file:///test/Foo.java"))
+            finally:
+                loop.close()
+        # If we get here without exception, the handler caught it correctly
 
 
 class TestFindLombokJar:
@@ -864,6 +882,32 @@ class TestFindLombokJar:
         with caplog.at_level(logging.WARNING, logger="java_functional_lsp.proxy"):
             _find_lombok_jar({"lombok": "/nonexistent/lombok.jar"})
         assert any("does not exist" in r.getMessage() for r in caplog.records)
+
+
+class TestDataDirHash:
+    """Tests that the data-dir hash includes Lombok jar path."""
+
+    def test_different_lombok_jars_produce_different_hashes(self) -> None:
+        import hashlib
+
+        root = "file:///workspace/products"
+
+        hash_without = hashlib.sha256(root.encode()).hexdigest()[:12]
+
+        hash_with_a = hashlib.sha256(f"{root}|lombok=/path/to/lombok-1.18.30.jar".encode()).hexdigest()[:12]
+
+        hash_with_b = hashlib.sha256(f"{root}|lombok=/path/to/lombok-1.18.34.jar".encode()).hexdigest()[:12]
+
+        assert hash_without != hash_with_a, "Adding Lombok should change the hash"
+        assert hash_with_a != hash_with_b, "Different Lombok versions should produce different hashes"
+
+    def test_no_lombok_preserves_original_hash(self) -> None:
+        import hashlib
+
+        root = "file:///workspace/products"
+        expected = hashlib.sha256(root.encode()).hexdigest()[:12]
+        # Without Lombok, hash_source is just the root — no "|lombok=" suffix
+        assert expected == hashlib.sha256(root.encode()).hexdigest()[:12]
 
 
 # Subprocess-based tests — zero mocks, real LSP transport

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -647,100 +647,29 @@ class TestServerInternals:
 # --------------------------------------------------------------------------
 
 
-class TestJdtlsFalsePositive:
-    """Tests for _is_jdtls_false_positive() — built-in patterns."""
-
-    def test_matches_builder_undefined(self) -> None:
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        diag = {"code": "67108964", "message": "The method builder() is undefined for the type Foo"}
-        assert _is_jdtls_false_positive(diag, []) is True
-
-    def test_matches_log_unresolved(self) -> None:
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        diag = {"code": "570425394", "message": "log cannot be resolved"}
-        assert _is_jdtls_false_positive(diag, []) is True
-
-    def test_matches_builder_type_unresolved(self) -> None:
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        diag = {"code": "16777218", "message": "FooBuilder cannot be resolved to a type"}
-        assert _is_jdtls_false_positive(diag, []) is True
-
-    def test_does_not_match_real_undefined_method(self) -> None:
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        diag = {"code": "67108964", "message": "The method foo() is undefined for the type String"}
-        assert _is_jdtls_false_positive(diag, []) is False
-
-    def test_does_not_match_real_unresolved_type(self) -> None:
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        diag = {"code": "16777218", "message": "SomeClass cannot be resolved to a type"}
-        assert _is_jdtls_false_positive(diag, []) is False
-
-    def test_empty_message(self) -> None:
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        diag = {"code": "67108964", "message": ""}
-        assert _is_jdtls_false_positive(diag, []) is False
-
-    def test_missing_fields(self) -> None:
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        assert _is_jdtls_false_positive({}, []) is False
-
-    def test_matches_blank_final_field(self) -> None:
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        diag = {"code": "33554513", "message": "The blank final field name may not have been initialized"}
-        assert _is_jdtls_false_positive(diag, []) is True
-
-    def test_matches_static_constructor_of(self) -> None:
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        diag = {"code": "67108964", "message": "The method of() is undefined for the type ExternalFailureError"}
-        assert _is_jdtls_false_positive(diag, []) is True
-
-    def test_matches_static_constructor_create(self) -> None:
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        diag = {"code": "67108964", "message": "The method create() is undefined for the type Config"}
-        assert _is_jdtls_false_positive(diag, []) is True
-
-    def test_does_not_match_of_without_undefined(self) -> None:
-        """Ensure 'of()' only matches in 'is undefined' context, not arbitrary messages."""
-        from java_functional_lsp.server import _is_jdtls_false_positive
-
-        diag = {"message": "The method of() has wrong return type"}
-        assert _is_jdtls_false_positive(diag, []) is False
-
-
 class TestUserSuppressPatterns:
     """Tests for configurable suppressJdtlsPatterns."""
 
     def test_user_pattern_matches(self) -> None:
-        """User pattern matches a message NOT covered by built-in patterns."""
-        from java_functional_lsp.server import _compile_user_patterns, _is_jdtls_false_positive
+        from java_functional_lsp.server import _compile_user_patterns, _is_jdtls_suppressed
 
         patterns = _compile_user_patterns({"suppressJdtlsPatterns": [r"The method generateReport\(\) is undefined"]})
         diag = {"message": "The method generateReport() is undefined for the type InternalService"}
-        assert _is_jdtls_false_positive(diag, patterns) is True
+        assert _is_jdtls_suppressed(diag, patterns) is True
 
     def test_user_pattern_does_not_match_unrelated(self) -> None:
-        from java_functional_lsp.server import _compile_user_patterns, _is_jdtls_false_positive
+        from java_functional_lsp.server import _compile_user_patterns, _is_jdtls_suppressed
 
         patterns = _compile_user_patterns({"suppressJdtlsPatterns": [r"The method generateReport\(\) is undefined"]})
         diag = {"message": "The method foo() is undefined for the type String"}
-        assert _is_jdtls_false_positive(diag, patterns) is False
+        assert _is_jdtls_suppressed(diag, patterns) is False
 
-    def test_user_pattern_without_builtins(self) -> None:
-        """With empty user patterns and a non-Lombok message, returns False."""
-        from java_functional_lsp.server import _is_jdtls_false_positive
+    def test_no_patterns_passes_everything(self) -> None:
+        """With no user patterns, nothing is suppressed."""
+        from java_functional_lsp.server import _is_jdtls_suppressed
 
-        diag = {"message": "The method generateReport() is undefined for the type InternalService"}
-        assert _is_jdtls_false_positive(diag, []) is False
+        diag = {"message": "The method builder() is undefined for the type Foo"}
+        assert _is_jdtls_suppressed(diag, []) is False
 
     def test_invalid_regex_skipped(self) -> None:
         from java_functional_lsp.server import _compile_user_patterns

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -884,30 +884,49 @@ class TestFindLombokJar:
         assert any("does not exist" in r.getMessage() for r in caplog.records)
 
 
-class TestDataDirHash:
-    """Tests that the data-dir hash includes Lombok jar path."""
+class TestCacheClear:
+    """Tests for _clear_cache_on_version_change()."""
 
-    def test_different_lombok_jars_produce_different_hashes(self) -> None:
-        import hashlib
+    def test_clears_on_version_mismatch(self, tmp_path: Any) -> None:
+        from java_functional_lsp.proxy import _clear_cache_on_version_change
 
-        root = "file:///workspace/products"
+        cache = tmp_path / "jdtls-data"
+        cache.mkdir()
+        stale_dir = cache / "abc123"
+        stale_dir.mkdir()
+        (cache / ".version").write_text("0.7.9")
 
-        hash_without = hashlib.sha256(root.encode()).hexdigest()[:12]
+        _clear_cache_on_version_change(cache)
 
-        hash_with_a = hashlib.sha256(f"{root}|lombok=/path/to/lombok-1.18.30.jar".encode()).hexdigest()[:12]
+        assert not stale_dir.exists(), "Stale data-dir should be cleared"
+        assert cache.exists(), "Cache root should be recreated"
+        from java_functional_lsp import __version__
 
-        hash_with_b = hashlib.sha256(f"{root}|lombok=/path/to/lombok-1.18.34.jar".encode()).hexdigest()[:12]
+        assert (cache / ".version").read_text() == __version__
 
-        assert hash_without != hash_with_a, "Adding Lombok should change the hash"
-        assert hash_with_a != hash_with_b, "Different Lombok versions should produce different hashes"
+    def test_keeps_cache_on_same_version(self, tmp_path: Any) -> None:
+        from java_functional_lsp import __version__
+        from java_functional_lsp.proxy import _clear_cache_on_version_change
 
-    def test_no_lombok_preserves_original_hash(self) -> None:
-        import hashlib
+        cache = tmp_path / "jdtls-data"
+        cache.mkdir()
+        existing_dir = cache / "abc123"
+        existing_dir.mkdir()
+        (cache / ".version").write_text(__version__)
 
-        root = "file:///workspace/products"
-        expected = hashlib.sha256(root.encode()).hexdigest()[:12]
-        # Without Lombok, hash_source is just the root — no "|lombok=" suffix
-        assert expected == hashlib.sha256(root.encode()).hexdigest()[:12]
+        _clear_cache_on_version_change(cache)
+
+        assert existing_dir.exists(), "Existing data-dir should be preserved"
+
+    def test_creates_marker_on_first_run(self, tmp_path: Any) -> None:
+        from java_functional_lsp.proxy import _clear_cache_on_version_change
+
+        cache = tmp_path / "jdtls-data"
+        _clear_cache_on_version_change(cache)
+
+        from java_functional_lsp import __version__
+
+        assert (cache / ".version").read_text() == __version__
 
 
 # Subprocess-based tests — zero mocks, real LSP transport

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -647,55 +647,160 @@ class TestServerInternals:
 # --------------------------------------------------------------------------
 
 
-class TestLombokFalsePositive:
-    """Tests for _is_lombok_false_positive()."""
+class TestJdtlsFalsePositive:
+    """Tests for _is_jdtls_false_positive() — built-in patterns."""
 
     def test_matches_builder_undefined(self) -> None:
-        from java_functional_lsp.server import _is_lombok_false_positive
+        from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "67108964", "message": "The method builder() is undefined for the type Foo"}
-        assert _is_lombok_false_positive(diag) is True
+        assert _is_jdtls_false_positive(diag) is True
 
     def test_matches_log_unresolved(self) -> None:
-        from java_functional_lsp.server import _is_lombok_false_positive
+        from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "570425394", "message": "log cannot be resolved"}
-        assert _is_lombok_false_positive(diag) is True
+        assert _is_jdtls_false_positive(diag) is True
 
     def test_matches_builder_type_unresolved(self) -> None:
-        from java_functional_lsp.server import _is_lombok_false_positive
+        from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "16777218", "message": "FooBuilder cannot be resolved to a type"}
-        assert _is_lombok_false_positive(diag) is True
+        assert _is_jdtls_false_positive(diag) is True
 
     def test_does_not_match_real_undefined_method(self) -> None:
-        from java_functional_lsp.server import _is_lombok_false_positive
+        from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "67108964", "message": "The method foo() is undefined for the type String"}
-        assert _is_lombok_false_positive(diag) is False
+        assert _is_jdtls_false_positive(diag) is False
 
     def test_does_not_match_real_unresolved_type(self) -> None:
-        from java_functional_lsp.server import _is_lombok_false_positive
+        from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "16777218", "message": "SomeClass cannot be resolved to a type"}
-        assert _is_lombok_false_positive(diag) is False
+        assert _is_jdtls_false_positive(diag) is False
 
     def test_empty_message(self) -> None:
-        from java_functional_lsp.server import _is_lombok_false_positive
+        from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "67108964", "message": ""}
-        assert _is_lombok_false_positive(diag) is False
+        assert _is_jdtls_false_positive(diag) is False
 
     def test_missing_fields(self) -> None:
-        from java_functional_lsp.server import _is_lombok_false_positive
+        from java_functional_lsp.server import _is_jdtls_false_positive
 
-        assert _is_lombok_false_positive({}) is False
+        assert _is_jdtls_false_positive({}) is False
 
     def test_matches_blank_final_field(self) -> None:
-        from java_functional_lsp.server import _is_lombok_false_positive
+        from java_functional_lsp.server import _is_jdtls_false_positive
 
         diag = {"code": "33554513", "message": "The blank final field name may not have been initialized"}
-        assert _is_lombok_false_positive(diag) is True
+        assert _is_jdtls_false_positive(diag) is True
+
+    def test_matches_static_constructor_of(self) -> None:
+        from java_functional_lsp.server import _is_jdtls_false_positive
+
+        diag = {"code": "67108964", "message": "The method of() is undefined for the type ExternalFailureError"}
+        assert _is_jdtls_false_positive(diag) is True
+
+    def test_matches_static_constructor_create(self) -> None:
+        from java_functional_lsp.server import _is_jdtls_false_positive
+
+        diag = {"code": "67108964", "message": "The method create() is undefined for the type Config"}
+        assert _is_jdtls_false_positive(diag) is True
+
+
+class TestUserSuppressPatterns:
+    """Tests for configurable suppressJdtlsPatterns."""
+
+    def test_user_pattern_matches(self) -> None:
+        import java_functional_lsp.server as srv
+        from java_functional_lsp.server import _compile_user_patterns, _is_jdtls_false_positive
+
+        old = srv._user_suppress_patterns
+        try:
+            srv._user_suppress_patterns = _compile_user_patterns(
+                {"suppressJdtlsPatterns": [r"The method \w+\(\) is undefined for the type \w+Error"]}
+            )
+            diag = {"message": "The method of() is undefined for the type SearchEngineError"}
+            assert _is_jdtls_false_positive(diag) is True
+        finally:
+            srv._user_suppress_patterns = old
+
+    def test_user_pattern_does_not_match_unrelated(self) -> None:
+        import java_functional_lsp.server as srv
+        from java_functional_lsp.server import _compile_user_patterns, _is_jdtls_false_positive
+
+        old = srv._user_suppress_patterns
+        try:
+            srv._user_suppress_patterns = _compile_user_patterns(
+                {"suppressJdtlsPatterns": [r"The method \w+\(\) is undefined for the type \w+Error"]}
+            )
+            diag = {"message": "The method foo() is undefined for the type String"}
+            assert _is_jdtls_false_positive(diag) is False
+        finally:
+            srv._user_suppress_patterns = old
+
+    def test_invalid_regex_skipped(self) -> None:
+        from java_functional_lsp.server import _compile_user_patterns
+
+        patterns = _compile_user_patterns({"suppressJdtlsPatterns": [r"valid", r"[invalid"]})
+        assert len(patterns) == 1
+
+    def test_non_list_ignored(self) -> None:
+        from java_functional_lsp.server import _compile_user_patterns
+
+        patterns = _compile_user_patterns({"suppressJdtlsPatterns": "not a list"})
+        assert patterns == []
+
+    def test_empty_config(self) -> None:
+        from java_functional_lsp.server import _compile_user_patterns
+
+        patterns = _compile_user_patterns({})
+        assert patterns == []
+
+
+class TestJdtlsIsolation:
+    """Tests that jdtls failures don't suppress custom diagnostics."""
+
+    def test_jdtls_exception_does_not_suppress_custom_diags(self) -> None:
+        """If jdtls diagnostic processing throws, custom diagnostics still publish."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import _run_analysis
+
+        java_source = "public class Foo { public String bar() { return null; } }"
+
+        # Simulate jdtls being available but get_cached_diagnostics throwing
+        with patch("java_functional_lsp.server.server") as mock_server:
+            mock_server._proxy.is_available = True
+            mock_server._proxy.get_cached_diagnostics.side_effect = RuntimeError("jdtls corrupt")
+            mock_server._config = {}
+            mock_server._parser = __import__("java_functional_lsp.analyzers.base", fromlist=["get_parser"]).get_parser()
+
+            result = _run_analysis(java_source, "file:///test/Foo.java")
+
+        # Custom diagnostics should still be present (null-return rule)
+        custom_diags = [d for d in result if d.source == "java-functional-lsp"]
+        assert len(custom_diags) > 0, "Custom diagnostics should publish even when jdtls fails"
+
+    def test_jdtls_unavailable_still_publishes_custom_diags(self) -> None:
+        """When jdtls is not available, custom diagnostics still publish."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import _run_analysis
+
+        java_source = "public class Foo { public String bar() { return null; } }"
+
+        with patch("java_functional_lsp.server.server") as mock_server:
+            mock_server._proxy.is_available = False
+            mock_server._config = {}
+            mock_server._parser = __import__("java_functional_lsp.analyzers.base", fromlist=["get_parser"]).get_parser()
+
+            result = _run_analysis(java_source, "file:///test/Foo.java")
+
+        custom_diags = [d for d in result if d.source == "java-functional-lsp"]
+        assert len(custom_diags) > 0, "Custom diagnostics should publish without jdtls"
 
 
 class TestFindLombokJar:

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.7.9"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary
- **Root cause fix**: clear jdtls cache on server version change via `.version` marker file — stale data-dirs from before the Lombok agent was added caused `AssertionFailedException` and silently broke `@Value(staticConstructor = "of")` processing
- **jdtls isolation**: wrap jdtls diagnostic processing in try/except so custom diagnostics (hints + code actions) **always** publish regardless of jdtls state
- **Error handling**: wrap all `_analyze_and_publish()` call sites (didOpen, didChange, didSave) to prevent server crashes
- **User-configurable suppression**: optional `suppressJdtlsPatterns` in `.java-functional-lsp.json` for project-specific edge cases
- **No built-in regex filters** — root cause is properly fixed, so no risk of hiding real compile errors

## Root cause
jdtls cached indexes at `~/.cache/jdtls-data/` were built before the Lombok agent was added. On restart, jdtls reused the corrupt state, threw `AssertionFailedException` on stderr, and silently failed to process Lombok annotations — even though the agent was loaded correctly. The fix stores a `.version` marker; on version mismatch the entire cache is wiped for a clean reindex. All blocking I/O (cache clearing, Lombok discovery, env build) runs in a single `run_in_executor` call to avoid blocking the event loop.

## Test plan
- [x] 379 tests pass, 83.8% coverage
- [x] E2E verified: `SearchEngineError.java` with `@Value(staticConstructor = "of")` → zero jdtls errors after cache clear
- [x] Custom diagnostics (`null-return`, `imperative-loop`) publish correctly
- [x] `TestCacheClear`: version mismatch clears cache, same version preserves it, first-run creates marker
- [x] `TestJdtlsIsolation`: jdtls exception does not suppress custom diagnostics
- [x] `TestUserSuppressPatterns`: user regex patterns match/reject correctly
- [x] Handler error isolation: `_deferred_validate` catches exceptions without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)