### PR TITLE
fix: auto-detect JetBrains IDEs and skip jdtls proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Use the [LSP4IJ](https://github.com/redhat-developer/lsp4ij) plugin (works on Co
 2. **Settings** → **Languages & Frameworks** → **Language Servers** → **`+`**
 3. Set **Command**: `java-functional-lsp`, then in **Mappings** → **File name patterns** add `*.java` with Language Id `java`
 
+The server automatically detects JetBrains IDEs and disables the jdtls proxy (IntelliJ provides native Java support). To force-enable jdtls, set `JAVA_FUNCTIONAL_LSP_JDTLS=on` in the server command environment.
+
 See [editors/intellij/README.md](editors/intellij/README.md) for detailed instructions.
 
 ### Claude Code

--- a/editors/intellij/README.md
+++ b/editors/intellij/README.md
@@ -73,7 +73,7 @@ Project-level rules are configured via `.java-functional-lsp.json` in your proje
 
 ## Coexistence with IntelliJ's Java Support
 
-LSP4IJ is designed to **supplement** IntelliJ's native Java support, not replace it. Your custom functional programming diagnostics appear alongside IntelliJ's built-in inspections. No conflicts.
+The server automatically detects JetBrains IDEs and disables the jdtls proxy — IntelliJ provides its own Java language features (completions, hover, go-to-definition, compile errors). Only the 16 custom functional programming rules run, and they appear alongside IntelliJ's built-in inspections.
 
 ## Troubleshooting
 
@@ -85,6 +85,7 @@ LSP4IJ is designed to **supplement** IntelliJ's native Java support, not replace
 - Ensure the file mapping is set to Language: `Java`, Language ID: `java`
 - Check that `.java-functional-lsp.json` doesn't have rules set to `"off"`
 - Try restarting the language server: **Tools** → **Language Servers** → **Restart**
+- If diagnostics worked before but stopped, the jdtls proxy may be interfering. Set `JAVA_FUNCTIONAL_LSP_JDTLS=off` in the server command environment to force-disable jdtls. The server auto-detects JetBrains IDEs and disables jdtls by default (since IntelliJ provides native Java support), but this can be overridden with `JAVA_FUNCTIONAL_LSP_JDTLS=on`.
 
 ### PATH not found
 - IntelliJ may not inherit your shell's PATH. Use the full absolute path to the binary in the server command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.8.0"
+version = "0.8.1"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -73,6 +73,7 @@ class JavaFunctionalLspServer(LanguageServer):
         self._user_suppress_patterns: list[re.Pattern[str]] = []
         self._skip_jdtls: bool = False
         self._skip_jdtls_registration: bool = False
+        self._init_generation: int = 0
 
     def _on_jdtls_diagnostics(self, uri: str, diagnostics: list[Any]) -> None:
         """Called when jdtls publishes diagnostics — merge with custom and re-publish.
@@ -206,6 +207,9 @@ def _jdtls_raw_to_lsp_diagnostics(raw_diagnostics: list[Any]) -> list[lsp.Diagno
     return result
 
 
+_MAX_PATTERN_LENGTH = 500  # Cap regex length to mitigate ReDoS from pathological patterns
+
+
 def _compile_user_patterns(config: dict[str, Any]) -> list[re.Pattern[str]]:
     """Compile user-defined suppressJdtlsPatterns from config."""
     raw = config.get("suppressJdtlsPatterns", [])
@@ -215,6 +219,9 @@ def _compile_user_patterns(config: dict[str, Any]) -> list[re.Pattern[str]]:
     patterns: list[re.Pattern[str]] = []
     for entry in raw:
         if not isinstance(entry, str):
+            continue
+        if len(entry) > _MAX_PATTERN_LENGTH:
+            logger.warning("suppressJdtlsPatterns entry too long (%d chars, max %d)", len(entry), _MAX_PATTERN_LENGTH)
             continue
         try:
             patterns.append(re.compile(entry))
@@ -284,13 +291,16 @@ def on_initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
     server._user_suppress_patterns = _compile_user_patterns(server._config)
 
     # Determine jdtls mode: env var takes priority, then auto-detect JetBrains IDEs.
-    client_name = params.client_info.name if params.client_info else ""
+    client_name = (params.client_info.name if params.client_info else "")[:200]
     logger.info("LSP client: %s", client_name or "(unknown)")
 
     # Reset flags so re-initialization (non-standard but defensive) starts clean.
+    # Bump generation so in-flight _register_jdtls_capabilities from a prior
+    # session detects the stale context and aborts.
     global _jdtls_capabilities_registered
     server._skip_jdtls = False
     server._skip_jdtls_registration = False
+    server._init_generation += 1
     _jdtls_capabilities_registered = False
 
     jdtls_override = os.environ.get("JAVA_FUNCTIONAL_LSP_JDTLS", "").strip().lower()
@@ -388,10 +398,14 @@ async def _register_jdtls_capabilities() -> None:
     ready, which suppresses the IDE's built-in diagnostic tooltips.
 
     Idempotent: safe to call multiple times (e.g., proxy restart).
+    Uses a generation counter to detect stale registrations from a prior
+    initialize cycle (defensive against non-standard re-initialization).
     """
     global _jdtls_capabilities_registered
     if _jdtls_capabilities_registered:
         return
+
+    generation = server._init_generation
 
     try:
         # Register handlers so pygls dispatches incoming requests to them.
@@ -401,6 +415,12 @@ async def _register_jdtls_capabilities() -> None:
         # Tell the client we now support these capabilities.
         registrations = _build_jdtls_registrations()
         await server.client_register_capability_async(lsp.RegistrationParams(registrations=registrations))
+
+        # Bail if a re-initialize happened while we were awaiting.
+        if generation != server._init_generation:
+            logger.info("Discarding stale jdtls capability registration (re-initialize detected)")
+            return
+
         _jdtls_capabilities_registered = True
         logger.info("Dynamically registered jdtls capabilities (hover, definition, references, completion, symbol)")
     except Exception:
@@ -448,22 +468,24 @@ async def on_did_open(params: lsp.DidOpenTextDocumentParams) -> None:
     """
     uri = params.text_document.uri
 
-    if not server._skip_jdtls:
+    if server._skip_jdtls:
+        # Skip all jdtls forwarding — custom diagnostics only.
+        pass
+    elif server._proxy.is_available:
+        # Fast path: jdtls running. Forward didOpen + add module if new.
         serialized = _serialize_params(params)
-
-        if server._proxy.is_available:
-            # Fast path: jdtls running. Forward didOpen + add module if new.
-            await server._proxy.send_notification("textDocument/didOpen", serialized)
-            await server._proxy.add_module_if_new(uri)
-        elif server._proxy._jdtls_on_path and not server._proxy._start_failed:
-            # Queue the didOpen (whether this is the first file or a subsequent one during startup).
-            server._proxy.queue_notification("textDocument/didOpen", serialized)
-            if not server._proxy._lazy_start_fired:
-                # First file: kick off lazy start in background.
-                server._proxy._lazy_start_fired = True
-                task = asyncio.create_task(_lazy_start_jdtls(uri))
-                _bg_tasks.add(task)
-                task.add_done_callback(_bg_tasks.discard)
+        await server._proxy.send_notification("textDocument/didOpen", serialized)
+        await server._proxy.add_module_if_new(uri)
+    elif server._proxy._jdtls_on_path and not server._proxy._start_failed:
+        # Queue the didOpen (whether this is the first file or a subsequent one during startup).
+        serialized = _serialize_params(params)
+        server._proxy.queue_notification("textDocument/didOpen", serialized)
+        if not server._proxy._lazy_start_fired:
+            # First file: kick off lazy start in background.
+            server._proxy._lazy_start_fired = True
+            task = asyncio.create_task(_lazy_start_jdtls(uri))
+            _bg_tasks.add(task)
+            task.add_done_callback(_bg_tasks.discard)
 
     # Custom diagnostics always publish immediately — never blocked by jdtls.
     try:

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -284,19 +284,24 @@ def on_initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
     server._user_suppress_patterns = _compile_user_patterns(server._config)
 
     # Determine jdtls mode: env var takes priority, then auto-detect JetBrains IDEs.
-    client_name = (params.client_info.name if params.client_info else None) or ""
+    client_name = params.client_info.name if params.client_info else ""
     logger.info("LSP client: %s", client_name or "(unknown)")
+
+    # Reset flags so re-initialization (non-standard but defensive) starts clean.
+    server._skip_jdtls = False
+    server._skip_jdtls_registration = False
 
     jdtls_override = os.environ.get("JAVA_FUNCTIONAL_LSP_JDTLS", "").lower()
     if jdtls_override == "off":
         server._skip_jdtls = True
         logger.info("jdtls proxy disabled via JAVA_FUNCTIONAL_LSP_JDTLS=off")
     elif jdtls_override == "on":
-        server._skip_jdtls = False
         logger.info("jdtls proxy force-enabled via JAVA_FUNCTIONAL_LSP_JDTLS=on")
     elif jdtls_override == "no-register":
         server._skip_jdtls_registration = True
         logger.info("jdtls dynamic registration disabled via JAVA_FUNCTIONAL_LSP_JDTLS=no-register")
+    elif jdtls_override:
+        logger.warning("Unknown JAVA_FUNCTIONAL_LSP_JDTLS value %r; expected off/on/no-register", jdtls_override)
     elif any(token in client_name for token in _JDTLS_SKIP_CLIENTS):
         server._skip_jdtls = True
         logger.info(

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -46,6 +47,10 @@ _ANALYZERS: list[Analyzer] = [
     FunctionalChecker(),
 ]
 
+# JetBrains IDE detection — all products contain one of these substrings in clientInfo.name.
+# When detected, jdtls is skipped because IntelliJ provides native Java language support.
+_JDTLS_SKIP_CLIENTS = ("IntelliJ", "JetBrains")
+
 #: LSP-aware cattrs converter. Unstructures to the LSP JSON shape
 #: (camelCase field names, discriminated unions, None-field pruning) and
 #: correspondingly structures from the same shape. Using a vanilla
@@ -66,6 +71,8 @@ class JavaFunctionalLspServer(LanguageServer):
         self._init_params: dict[str, Any] = {}
         self._proxy = JdtlsProxy(on_diagnostics=self._on_jdtls_diagnostics)
         self._user_suppress_patterns: list[re.Pattern[str]] = []
+        self._skip_jdtls: bool = False
+        self._skip_jdtls_registration: bool = False
 
     def _on_jdtls_diagnostics(self, uri: str, diagnostics: list[Any]) -> None:
         """Called when jdtls publishes diagnostics — merge with custom and re-publish.
@@ -276,6 +283,28 @@ def on_initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
     server._config = _load_config(root)
     server._user_suppress_patterns = _compile_user_patterns(server._config)
 
+    # Determine jdtls mode: env var takes priority, then auto-detect JetBrains IDEs.
+    client_name = (params.client_info.name if params.client_info else None) or ""
+    logger.info("LSP client: %s", client_name or "(unknown)")
+
+    jdtls_override = os.environ.get("JAVA_FUNCTIONAL_LSP_JDTLS", "").lower()
+    if jdtls_override == "off":
+        server._skip_jdtls = True
+        logger.info("jdtls proxy disabled via JAVA_FUNCTIONAL_LSP_JDTLS=off")
+    elif jdtls_override == "on":
+        server._skip_jdtls = False
+        logger.info("jdtls proxy force-enabled via JAVA_FUNCTIONAL_LSP_JDTLS=on")
+    elif jdtls_override == "no-register":
+        server._skip_jdtls_registration = True
+        logger.info("jdtls dynamic registration disabled via JAVA_FUNCTIONAL_LSP_JDTLS=no-register")
+    elif any(token in client_name for token in _JDTLS_SKIP_CLIENTS):
+        server._skip_jdtls = True
+        logger.info(
+            "JetBrains IDE detected (%s) — skipping jdtls proxy "
+            "(IDE provides native Java support; override with JAVA_FUNCTIONAL_LSP_JDTLS=on)",
+            client_name,
+        )
+
     return lsp.InitializeResult(
         capabilities=lsp.ServerCapabilities(
             text_document_sync=lsp.TextDocumentSyncOptions(
@@ -302,6 +331,9 @@ async def on_initialized(params: lsp.InitializedParams) -> None:
         "java-functional-lsp initialized (rules: %s)",
         list(server._config.get("rules", {}).keys()) or "all defaults",
     )
+    if server._skip_jdtls:
+        logger.info("jdtls proxy disabled — custom rules only")
+        return
     if server._proxy.check_available():
         logger.info("jdtls found on PATH — will start lazily on first file open")
     else:
@@ -389,6 +421,8 @@ async def _deferred_validate(uri: str) -> None:
 
 def _forward_or_queue(method: str, serialized: Any) -> None:
     """Forward a notification to jdtls if available, or queue it if starting."""
+    if server._skip_jdtls:
+        return
     if server._proxy.is_available:
         task = asyncio.create_task(server._proxy.send_notification(method, serialized))
         _bg_tasks.add(task)
@@ -406,21 +440,23 @@ async def on_did_open(params: lsp.DidOpenTextDocumentParams) -> None:
     didOpen response isn't delayed by jdtls cold-start.
     """
     uri = params.text_document.uri
-    serialized = _serialize_params(params)
 
-    if server._proxy.is_available:
-        # Fast path: jdtls running. Forward didOpen + add module if new.
-        await server._proxy.send_notification("textDocument/didOpen", serialized)
-        await server._proxy.add_module_if_new(uri)
-    elif server._proxy._jdtls_on_path and not server._proxy._start_failed:
-        # Queue the didOpen (whether this is the first file or a subsequent one during startup).
-        server._proxy.queue_notification("textDocument/didOpen", serialized)
-        if not server._proxy._lazy_start_fired:
-            # First file: kick off lazy start in background.
-            server._proxy._lazy_start_fired = True
-            task = asyncio.create_task(_lazy_start_jdtls(uri))
-            _bg_tasks.add(task)
-            task.add_done_callback(_bg_tasks.discard)
+    if not server._skip_jdtls:
+        serialized = _serialize_params(params)
+
+        if server._proxy.is_available:
+            # Fast path: jdtls running. Forward didOpen + add module if new.
+            await server._proxy.send_notification("textDocument/didOpen", serialized)
+            await server._proxy.add_module_if_new(uri)
+        elif server._proxy._jdtls_on_path and not server._proxy._start_failed:
+            # Queue the didOpen (whether this is the first file or a subsequent one during startup).
+            server._proxy.queue_notification("textDocument/didOpen", serialized)
+            if not server._proxy._lazy_start_fired:
+                # First file: kick off lazy start in background.
+                server._proxy._lazy_start_fired = True
+                task = asyncio.create_task(_lazy_start_jdtls(uri))
+                _bg_tasks.add(task)
+                task.add_done_callback(_bg_tasks.discard)
 
     # Custom diagnostics always publish immediately — never blocked by jdtls.
     try:
@@ -474,7 +510,10 @@ async def _lazy_start_jdtls(file_uri: str) -> None:
         started = await server._proxy.ensure_started(server._init_params, file_uri, config=server._config)
         if started:
             logger.info("jdtls proxy active — full Java language support enabled")
-            await _register_jdtls_capabilities()
+            if not server._skip_jdtls_registration:
+                await _register_jdtls_capabilities()
+            else:
+                logger.info("Skipping dynamic capability registration (no-register mode)")
             await server._proxy.flush_queued_notifications()
     except Exception:
         logger.warning("jdtls lazy start failed", exc_info=True)

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -288,8 +288,10 @@ def on_initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
     logger.info("LSP client: %s", client_name or "(unknown)")
 
     # Reset flags so re-initialization (non-standard but defensive) starts clean.
+    global _jdtls_capabilities_registered
     server._skip_jdtls = False
     server._skip_jdtls_registration = False
+    _jdtls_capabilities_registered = False
 
     jdtls_override = os.environ.get("JAVA_FUNCTIONAL_LSP_JDTLS", "").lower()
     if jdtls_override == "off":
@@ -515,10 +517,10 @@ async def _lazy_start_jdtls(file_uri: str) -> None:
         started = await server._proxy.ensure_started(server._init_params, file_uri, config=server._config)
         if started:
             logger.info("jdtls proxy active — full Java language support enabled")
-            if not server._skip_jdtls_registration:
-                await _register_jdtls_capabilities()
-            else:
+            if server._skip_jdtls_registration:
                 logger.info("Skipping dynamic capability registration (no-register mode)")
+            else:
+                await _register_jdtls_capabilities()
             await server._proxy.flush_queued_notifications()
     except Exception:
         logger.warning("jdtls lazy start failed", exc_info=True)

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -293,7 +293,7 @@ def on_initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
     server._skip_jdtls_registration = False
     _jdtls_capabilities_registered = False
 
-    jdtls_override = os.environ.get("JAVA_FUNCTIONAL_LSP_JDTLS", "").lower()
+    jdtls_override = os.environ.get("JAVA_FUNCTIONAL_LSP_JDTLS", "").strip().lower()
     if jdtls_override == "off":
         server._skip_jdtls = True
         logger.info("jdtls proxy disabled via JAVA_FUNCTIONAL_LSP_JDTLS=off")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -761,94 +761,65 @@ class TestJdtlsSkipDetection:
             client_info=lsp.ClientInfo(name=client_name) if client_name else None,
         )
 
-    def test_intellij_client_info_skips_jdtls(self) -> None:
+    def _run_init(self, monkeypatch: Any, client_name: str | None, env_value: str | None = None) -> None:
+        """Run on_initialize with controlled env and client_info."""
+        from java_functional_lsp.server import on_initialize, server
+
+        server._skip_jdtls = False
+        server._skip_jdtls_registration = False
+        if env_value is not None:
+            monkeypatch.setenv("JAVA_FUNCTIONAL_LSP_JDTLS", env_value)
+        else:
+            monkeypatch.delenv("JAVA_FUNCTIONAL_LSP_JDTLS", raising=False)
+        on_initialize(self._make_init_params(client_name))
+
+    def test_intellij_client_info_skips_jdtls(self, monkeypatch: Any) -> None:
         """IntelliJ IDEA detected → _skip_jdtls = True."""
-        from unittest.mock import patch
+        from java_functional_lsp.server import server
 
-        from java_functional_lsp.server import on_initialize, server
-
-        server._skip_jdtls = False
-        server._skip_jdtls_registration = False
-        params = self._make_init_params("IntelliJ IDEA")
-        with patch.dict("os.environ", {}, clear=False):
-            os.environ.pop("JAVA_FUNCTIONAL_LSP_JDTLS", None)
-            on_initialize(params)
+        self._run_init(monkeypatch, "IntelliJ IDEA")
         assert server._skip_jdtls is True
 
-    def test_jetbrains_product_skips_jdtls(self) -> None:
+    def test_jetbrains_product_skips_jdtls(self, monkeypatch: Any) -> None:
         """Any JetBrains product detected → _skip_jdtls = True."""
-        from unittest.mock import patch
+        from java_functional_lsp.server import server
 
-        from java_functional_lsp.server import on_initialize, server
-
-        server._skip_jdtls = False
-        params = self._make_init_params("JetBrains Rider 2025.2")
-        with patch.dict("os.environ", {}, clear=False):
-            os.environ.pop("JAVA_FUNCTIONAL_LSP_JDTLS", None)
-            on_initialize(params)
+        self._run_init(monkeypatch, "JetBrains Rider 2025.2")
         assert server._skip_jdtls is True
 
-    def test_vscode_allows_jdtls(self) -> None:
+    def test_vscode_allows_jdtls(self, monkeypatch: Any) -> None:
         """VS Code → _skip_jdtls = False (jdtls needed)."""
-        from unittest.mock import patch
+        from java_functional_lsp.server import server
 
-        from java_functional_lsp.server import on_initialize, server
-
-        server._skip_jdtls = False
-        params = self._make_init_params("Visual Studio Code")
-        with patch.dict("os.environ", {}, clear=False):
-            os.environ.pop("JAVA_FUNCTIONAL_LSP_JDTLS", None)
-            on_initialize(params)
+        self._run_init(monkeypatch, "Visual Studio Code")
         assert server._skip_jdtls is False
 
-    def test_no_client_info_allows_jdtls(self) -> None:
+    def test_no_client_info_allows_jdtls(self, monkeypatch: Any) -> None:
         """No client_info → _skip_jdtls = False (safe default)."""
-        from unittest.mock import patch
+        from java_functional_lsp.server import server
 
-        from java_functional_lsp.server import on_initialize, server
-
-        server._skip_jdtls = False
-        params = self._make_init_params(None)
-        with patch.dict("os.environ", {}, clear=False):
-            os.environ.pop("JAVA_FUNCTIONAL_LSP_JDTLS", None)
-            on_initialize(params)
+        self._run_init(monkeypatch, None)
         assert server._skip_jdtls is False
 
-    def test_env_var_off_overrides_detection(self) -> None:
+    def test_env_var_off_overrides_detection(self, monkeypatch: Any) -> None:
         """JAVA_FUNCTIONAL_LSP_JDTLS=off disables jdtls even for non-JetBrains client."""
-        from unittest.mock import patch
+        from java_functional_lsp.server import server
 
-        from java_functional_lsp.server import on_initialize, server
-
-        server._skip_jdtls = False
-        params = self._make_init_params("Visual Studio Code")
-        with patch.dict("os.environ", {"JAVA_FUNCTIONAL_LSP_JDTLS": "off"}):
-            on_initialize(params)
+        self._run_init(monkeypatch, "Visual Studio Code", env_value="off")
         assert server._skip_jdtls is True
 
-    def test_env_var_on_overrides_intellij_detection(self) -> None:
+    def test_env_var_on_overrides_intellij_detection(self, monkeypatch: Any) -> None:
         """JAVA_FUNCTIONAL_LSP_JDTLS=on force-enables jdtls even for IntelliJ."""
-        from unittest.mock import patch
+        from java_functional_lsp.server import server
 
-        from java_functional_lsp.server import on_initialize, server
-
-        server._skip_jdtls = True  # Pre-set to True
-        params = self._make_init_params("IntelliJ IDEA")
-        with patch.dict("os.environ", {"JAVA_FUNCTIONAL_LSP_JDTLS": "on"}):
-            on_initialize(params)
+        self._run_init(monkeypatch, "IntelliJ IDEA", env_value="on")
         assert server._skip_jdtls is False
 
-    def test_env_var_no_register(self) -> None:
+    def test_env_var_no_register(self, monkeypatch: Any) -> None:
         """JAVA_FUNCTIONAL_LSP_JDTLS=no-register keeps jdtls but skips registration."""
-        from unittest.mock import patch
+        from java_functional_lsp.server import server
 
-        from java_functional_lsp.server import on_initialize, server
-
-        server._skip_jdtls = False
-        server._skip_jdtls_registration = False
-        params = self._make_init_params("Visual Studio Code")
-        with patch.dict("os.environ", {"JAVA_FUNCTIONAL_LSP_JDTLS": "no-register"}):
-            on_initialize(params)
+        self._run_init(monkeypatch, "Visual Studio Code", env_value="no-register")
         assert server._skip_jdtls is False
         assert server._skip_jdtls_registration is True
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -750,6 +750,129 @@ class TestJdtlsIsolation:
         # If we get here without exception, the handler caught it correctly
 
 
+class TestJdtlsSkipDetection:
+    """Tests for auto-detecting JetBrains IDEs and skipping jdtls."""
+
+    def _make_init_params(self, client_name: str | None = None) -> Any:
+        """Create minimal InitializeParams with optional client_info."""
+        return lsp.InitializeParams(
+            capabilities=lsp.ClientCapabilities(),
+            root_uri="file:///tmp/test",
+            client_info=lsp.ClientInfo(name=client_name) if client_name else None,
+        )
+
+    def test_intellij_client_info_skips_jdtls(self) -> None:
+        """IntelliJ IDEA detected → _skip_jdtls = True."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import on_initialize, server
+
+        server._skip_jdtls = False
+        server._skip_jdtls_registration = False
+        params = self._make_init_params("IntelliJ IDEA")
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("JAVA_FUNCTIONAL_LSP_JDTLS", None)
+            on_initialize(params)
+        assert server._skip_jdtls is True
+
+    def test_jetbrains_product_skips_jdtls(self) -> None:
+        """Any JetBrains product detected → _skip_jdtls = True."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import on_initialize, server
+
+        server._skip_jdtls = False
+        params = self._make_init_params("JetBrains Rider 2025.2")
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("JAVA_FUNCTIONAL_LSP_JDTLS", None)
+            on_initialize(params)
+        assert server._skip_jdtls is True
+
+    def test_vscode_allows_jdtls(self) -> None:
+        """VS Code → _skip_jdtls = False (jdtls needed)."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import on_initialize, server
+
+        server._skip_jdtls = False
+        params = self._make_init_params("Visual Studio Code")
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("JAVA_FUNCTIONAL_LSP_JDTLS", None)
+            on_initialize(params)
+        assert server._skip_jdtls is False
+
+    def test_no_client_info_allows_jdtls(self) -> None:
+        """No client_info → _skip_jdtls = False (safe default)."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import on_initialize, server
+
+        server._skip_jdtls = False
+        params = self._make_init_params(None)
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("JAVA_FUNCTIONAL_LSP_JDTLS", None)
+            on_initialize(params)
+        assert server._skip_jdtls is False
+
+    def test_env_var_off_overrides_detection(self) -> None:
+        """JAVA_FUNCTIONAL_LSP_JDTLS=off disables jdtls even for non-JetBrains client."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import on_initialize, server
+
+        server._skip_jdtls = False
+        params = self._make_init_params("Visual Studio Code")
+        with patch.dict("os.environ", {"JAVA_FUNCTIONAL_LSP_JDTLS": "off"}):
+            on_initialize(params)
+        assert server._skip_jdtls is True
+
+    def test_env_var_on_overrides_intellij_detection(self) -> None:
+        """JAVA_FUNCTIONAL_LSP_JDTLS=on force-enables jdtls even for IntelliJ."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import on_initialize, server
+
+        server._skip_jdtls = True  # Pre-set to True
+        params = self._make_init_params("IntelliJ IDEA")
+        with patch.dict("os.environ", {"JAVA_FUNCTIONAL_LSP_JDTLS": "on"}):
+            on_initialize(params)
+        assert server._skip_jdtls is False
+
+    def test_env_var_no_register(self) -> None:
+        """JAVA_FUNCTIONAL_LSP_JDTLS=no-register keeps jdtls but skips registration."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import on_initialize, server
+
+        server._skip_jdtls = False
+        server._skip_jdtls_registration = False
+        params = self._make_init_params("Visual Studio Code")
+        with patch.dict("os.environ", {"JAVA_FUNCTIONAL_LSP_JDTLS": "no-register"}):
+            on_initialize(params)
+        assert server._skip_jdtls is False
+        assert server._skip_jdtls_registration is True
+
+    def test_custom_diagnostics_publish_when_jdtls_skipped(self) -> None:
+        """Tree-sitter analysis works normally when jdtls is skipped."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import _run_analysis
+
+        java_source = "public class Foo { public String bar() { return null; } }"
+
+        with patch("java_functional_lsp.server.server") as mock_server:
+            mock_server._proxy.is_available = False
+            mock_server._skip_jdtls = True
+            mock_server._config = {}
+            mock_server._parser = __import__("java_functional_lsp.analyzers.base", fromlist=["get_parser"]).get_parser()
+
+            result = _run_analysis(java_source, "file:///test/Foo.java")
+
+        custom_diags = [d for d in result if d.source == "java-functional-lsp"]
+        assert len(custom_diags) > 0, "Custom diagnostics should publish when jdtls is skipped"
+        assert any(d.code == "null-return" for d in custom_diags), "null-return diagnostic expected"
+
+
 class TestFindLombokJar:
     """Tests for _find_lombok_jar()."""
 


### PR DESCRIPTION
## Summary
- Auto-detect JetBrains IDEs from `params.client_info.name` and skip jdtls proxy — IntelliJ provides native Java support, so jdtls is redundant and its dynamic capability registration breaks LSP4IJ diagnostic rendering
- Env var override `JAVA_FUNCTIONAL_LSP_JDTLS=off/on/no-register` for manual control and root cause debugging
- Custom tree-sitter diagnostics + code actions continue normally (restored to pre-jdtls behavior for IntelliJ)

## Root Cause
After v0.8.0 added jdtls proxy support, IntelliJ with LSP4IJ stopped rendering diagnostics despite the server publishing them correctly. The `client/registerCapability` for hover/definition/references/completion/document-symbol conflicts with IntelliJ's native Java support, causing LSP4IJ to suppress diagnostic annotations.

### Investigation (debug ensemble + researcher)
- Server-side confirmed correct: `publishDiagnostics` sent with valid payloads
- LSP4IJ 0.19.2 confirmed (past known bug fixes in 0.12.x and 0.15.0)
- Dynamic registration payload verified valid (standard LSP format)
- jdtls→client requests silently dropped by proxy (no forwarding of jdtls's own registrations)
- LSP4IJ research: `EditorFeatureManager.refreshEditorFeature()` triggered on registration, but NOT the `LSPDiagnosticAnnotator` — likely causes IntelliJ to deprioritize the LSP server's diagnostics

### Fix approach
- Auto-detect JetBrains IDEs via `clientInfo.name` substring match (`"IntelliJ"`, `"JetBrains"`)
- Skip all jdtls (startup, forwarding, dynamic registration) for detected IDEs
- `no-register` debug mode to isolate whether registration alone is the root cause
- Defensive flag reset on re-initialization (including `_jdtls_capabilities_registered` global)

## Reviews passed
- Review ensemble: **APPROVE** (unanimous 3/3 — correctness, security, quality)
- LSP skill review: No protocol violations, all lifecycle paths correct
- Tree-sitter skill review: Key invariant verified — analysis runs unconditionally in all 4 handlers

## Test plan
- [x] 387 tests pass (8 new), 83.67% coverage
- [x] `ruff check`, `ruff format`, `mypy` all clean
- [ ] Verify in IntelliJ: restart → open .java file → custom diagnostics visible
- [ ] Verify `JAVA_FUNCTIONAL_LSP_JDTLS=no-register` isolates dynamic registration as root cause
- [ ] Verify VS Code / Claude Code / Neovim unaffected (jdtls starts normally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)