### PR TITLE
feat: Merkle-tree module snapshot for incremental file reload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.8.1"
+version = "0.9.0"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"

--- a/src/java_functional_lsp/merkle.py
+++ b/src/java_functional_lsp/merkle.py
@@ -139,8 +139,10 @@ class ModuleSnapshot:
         payload = json.dumps({"root": self.root_hash, "files": self.files}, separators=(",", ":"))
         fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
         try:
-            os.write(fd, payload.encode())
-            os.close(fd)
+            try:
+                os.write(fd, payload.encode())
+            finally:
+                os.close(fd)
             os.replace(tmp, path)
         except Exception:
             try:

--- a/src/java_functional_lsp/merkle.py
+++ b/src/java_functional_lsp/merkle.py
@@ -32,10 +32,20 @@ _MAX_FILES = 20_000
 # Upper bound on entries in a persisted snapshot (sanity / DoS guard).
 _MAX_SNAPSHOT_FILES = 100_000
 
+_READ_CHUNK = 65536  # 64 KiB per read — bounds per-file memory usage during hashing
 
-def _blake2b_hex(data: bytes) -> str:
-    """Return a 64-char hex digest of *data* using BLAKE2b (256-bit output)."""
-    return hashlib.blake2b(data, digest_size=32).hexdigest()
+
+def _blake2b_file(path: Path) -> str:
+    """Return a 64-char BLAKE2b hex digest of *path*, reading in 64 KiB chunks.
+
+    Streams the file instead of loading it entirely into memory, bounding
+    per-file heap usage to ``_READ_CHUNK`` bytes regardless of file size.
+    """
+    h = hashlib.blake2b(digest_size=32)
+    with path.open("rb") as fh:
+        while chunk := fh.read(_READ_CHUNK):
+            h.update(chunk)
+    return h.hexdigest()
 
 
 @dataclass(frozen=True)
@@ -103,14 +113,15 @@ class ModuleSnapshot:
                 return None
             rel = str(file_path.relative_to(module_root))
             try:
-                content = file_path.read_bytes()
-                files[rel] = _blake2b_hex(content)
+                files[rel] = _blake2b_file(file_path)
             except OSError as exc:
                 logger.debug("merkle: could not read %s: %s", file_path, exc)
 
-        root_input = "\n".join(f"{p}:{h}" for p, h in sorted(files.items()))
-        root_hash = hashlib.blake2b(root_input.encode(), digest_size=32).hexdigest()
-        return cls(root_hash=root_hash, files=files)
+        # Build root hash incrementally — avoids allocating an O(N) intermediate string.
+        h = hashlib.blake2b(digest_size=32)
+        for p, fh in sorted(files.items()):
+            h.update(f"{p}:{fh}\n".encode())
+        return cls(root_hash=h.hexdigest(), files=files)
 
     # ------------------------------------------------------------------
     # Comparison
@@ -168,8 +179,8 @@ class ModuleSnapshot:
                 isinstance(k, str)
                 and isinstance(v, str)
                 and "\x00" not in k
-                and not Path(k).is_absolute()
-                and ".." not in Path(k).parts
+                and not (p := Path(k)).is_absolute()
+                and ".." not in p.parts
                 for k, v in files.items()
             )
             return cls(root_hash=root_hash, files=files) if valid else None

--- a/src/java_functional_lsp/merkle.py
+++ b/src/java_functional_lsp/merkle.py
@@ -9,6 +9,7 @@ instead of a full cold-start re-index.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -52,8 +53,7 @@ class TreeDiff:
     @property
     def has_build_file_changes(self) -> bool:
         """True if any build file (pom.xml, build.gradle, …) changed."""
-        all_changed = self.added | self.modified | self.removed
-        return any(Path(p).name in _BUILD_FILES for p in all_changed)
+        return any(Path(p).name in _BUILD_FILES for bucket in (self.added, self.modified, self.removed) for p in bucket)
 
     @property
     def all_changed(self) -> frozenset[str]:
@@ -120,8 +120,8 @@ class ModuleSnapshot:
         """Return what changed between *self* (old) and *newer* (current)."""
         old = self.files
         new = newer.files
-        added = frozenset(new) - frozenset(old)
-        removed = frozenset(old) - frozenset(new)
+        added = frozenset(new.keys() - old.keys())
+        removed = frozenset(old.keys() - new.keys())
         modified = frozenset(p for p in old.keys() & new.keys() if old[p] != new[p])
         return TreeDiff(added=added, modified=modified, removed=removed)
 
@@ -139,16 +139,12 @@ class ModuleSnapshot:
         payload = json.dumps({"root": self.root_hash, "files": self.files}, separators=(",", ":"))
         fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
         try:
-            try:
-                os.write(fd, payload.encode())
-            finally:
-                os.close(fd)
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(payload.encode())
             os.replace(tmp, path)
         except Exception:
-            try:
+            with contextlib.suppress(OSError):
                 os.unlink(tmp)
-            except OSError:
-                pass
             raise
 
     @classmethod
@@ -177,7 +173,7 @@ class ModuleSnapshot:
                 for k, v in files.items()
             )
             return cls(root_hash=root_hash, files=files) if valid else None
-        except (OSError, KeyError, json.JSONDecodeError, ValueError):
+        except (OSError, KeyError, ValueError):
             return None
 
 
@@ -196,7 +192,7 @@ def _iter_tracked_files(module_root: Path) -> Iterator[Path]:
     """
     module_resolved = module_root.resolve()
 
-    for dirpath_str, dirnames, filenames in os.walk(str(module_root), followlinks=False):
+    for dirpath_str, dirnames, filenames in os.walk(module_root, followlinks=False):
         # Prune skip dirs in-place to stop os.walk from descending into them.
         dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
 

--- a/src/java_functional_lsp/merkle.py
+++ b/src/java_functional_lsp/merkle.py
@@ -1,0 +1,213 @@
+"""Module snapshot tracking for incremental file-change detection between sessions.
+
+Each Java module's source files are hashed into a ``ModuleSnapshot``.
+On the next plugin session the stored snapshot is compared against the
+current one; only files that actually changed are forwarded to jdtls via
+``workspace/didChangeWatchedFiles``, letting it do an incremental rebuild
+instead of a full cold-start re-index.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Files and directories tracked / skipped during snapshot.
+_BUILD_FILES: frozenset[str] = frozenset({"pom.xml", "build.gradle", "build.gradle.kts"})
+_SKIP_DIRS: frozenset[str] = frozenset({"target", ".git", "node_modules", ".gradle", "build", ".idea", ".mvn"})
+
+# Safety bound: modules larger than this are skipped to prevent multi-second
+# executor stalls (e.g., when jdtls is scoped to the monorepo root).
+_MAX_FILES = 20_000
+
+# Upper bound on entries in a persisted snapshot (sanity / DoS guard).
+_MAX_SNAPSHOT_FILES = 100_000
+
+
+def _blake2b_hex(data: bytes) -> str:
+    """Return a 64-char hex digest of *data* using BLAKE2b (256-bit output)."""
+    return hashlib.blake2b(data, digest_size=32).hexdigest()
+
+
+@dataclass(frozen=True)
+class TreeDiff:
+    """Set-based diff between two ``ModuleSnapshot`` instances."""
+
+    added: frozenset[str]
+    modified: frozenset[str]
+    removed: frozenset[str]
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.added or self.modified or self.removed)
+
+    @property
+    def has_build_file_changes(self) -> bool:
+        """True if any build file (pom.xml, build.gradle, …) changed."""
+        all_changed = self.added | self.modified | self.removed
+        return any(Path(p).name in _BUILD_FILES for p in all_changed)
+
+    @property
+    def all_changed(self) -> frozenset[str]:
+        """Union of added and modified relative paths (files present on disk)."""
+        return self.added | self.modified
+
+
+@dataclass
+class ModuleSnapshot:
+    """Snapshot of a Java module's tracked source files.
+
+    ``root_hash`` is a BLAKE2b hash of all ``(relative_path, content_hash)``
+    pairs sorted by path.  Two snapshots with the same ``root_hash`` are
+    identical; this enables an O(1) equality check before the O(N) per-file
+    diff.
+
+    ``files`` maps each tracked relative path to the BLAKE2b hash of its
+    content at snapshot time.
+    """
+
+    root_hash: str
+    files: dict[str, str]  # relative path → content hash
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def build(cls, module_root: Path) -> ModuleSnapshot | None:
+        """Scan *module_root* and return a snapshot, or ``None`` if too large.
+
+        Tracked files: ``*.java`` + ``pom.xml`` / ``build.gradle`` /
+        ``build.gradle.kts``.  Directories in ``_SKIP_DIRS`` (``target``,
+        ``.git``, ``node_modules``, …) are pruned from the walk entirely.
+        Symlinks are skipped.  Paths that resolve outside *module_root* are
+        rejected (defense-in-depth against directory traversal).
+        """
+        files: dict[str, str] = {}
+
+        for file_path in _iter_tracked_files(module_root):
+            if len(files) >= _MAX_FILES:
+                logger.warning(
+                    "merkle: module %s has ≥%d tracked files — skipping snapshot",
+                    module_root,
+                    _MAX_FILES,
+                )
+                return None
+            rel = str(file_path.relative_to(module_root))
+            try:
+                content = file_path.read_bytes()
+                files[rel] = _blake2b_hex(content)
+            except OSError as exc:
+                logger.debug("merkle: could not read %s: %s", file_path, exc)
+
+        root_input = "\n".join(f"{p}:{h}" for p, h in sorted(files.items()))
+        root_hash = hashlib.blake2b(root_input.encode(), digest_size=32).hexdigest()
+        return cls(root_hash=root_hash, files=files)
+
+    # ------------------------------------------------------------------
+    # Comparison
+    # ------------------------------------------------------------------
+
+    def diff(self, newer: ModuleSnapshot) -> TreeDiff:
+        """Return what changed between *self* (old) and *newer* (current)."""
+        old = self.files
+        new = newer.files
+        added = frozenset(new) - frozenset(old)
+        removed = frozenset(old) - frozenset(new)
+        modified = frozenset(p for p in old.keys() & new.keys() if old[p] != new[p])
+        return TreeDiff(added=added, modified=modified, removed=removed)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def save(self, path: Path) -> None:
+        """Atomically write snapshot to *path* (write to temp then rename).
+
+        The parent directory is created with mode ``0o700`` (owner-only) on
+        first use to prevent other local users from tampering with the cache.
+        """
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        payload = json.dumps({"root": self.root_hash, "files": self.files}, separators=(",", ":"))
+        fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        try:
+            os.write(fd, payload.encode())
+            os.close(fd)
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+
+    @classmethod
+    def load(cls, path: Path) -> ModuleSnapshot | None:
+        """Load a snapshot from *path*.
+
+        Returns ``None`` on missing file, JSON parse error, or invalid
+        content (path traversal attempts, oversized entries, wrong types).
+        Never raises.
+        """
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            root_hash = data["root"]
+            files = data["files"]
+            if not isinstance(root_hash, str) or not isinstance(files, dict):
+                return None
+            if len(files) > _MAX_SNAPSHOT_FILES:
+                return None
+            # Validate each entry: relative, no traversal, no nulls, str values.
+            valid = all(
+                isinstance(k, str)
+                and isinstance(v, str)
+                and "\x00" not in k
+                and not Path(k).is_absolute()
+                and ".." not in Path(k).parts
+                for k, v in files.items()
+            )
+            return cls(root_hash=root_hash, files=files) if valid else None
+        except (OSError, KeyError, json.JSONDecodeError, ValueError):
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_tracked_files(module_root: Path) -> Iterator[Path]:
+    """Yield ``.java`` and build files under *module_root*.
+
+    Uses ``os.walk`` with ``followlinks=False`` and prunes ``_SKIP_DIRS``
+    in-place so entire subtrees (``target/``, ``.git/``, …) are never
+    entered.  Symlink files are skipped individually.  Any path that resolves
+    outside *module_root* after symlink expansion is rejected.
+    """
+    module_resolved = module_root.resolve()
+
+    for dirpath_str, dirnames, filenames in os.walk(str(module_root), followlinks=False):
+        # Prune skip dirs in-place to stop os.walk from descending into them.
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+
+        dir_path = Path(dirpath_str)
+        for fname in filenames:
+            if not (fname.endswith(".java") or fname in _BUILD_FILES):
+                continue
+            file_path = dir_path / fname
+            if file_path.is_symlink():
+                continue
+            # Reject any path whose resolved form escapes the module root.
+            try:
+                file_path.resolve().relative_to(module_resolved)
+            except ValueError:
+                continue
+            yield file_path

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -19,6 +19,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from .merkle import ModuleSnapshot, TreeDiff
+
 logger = logging.getLogger(__name__)
 
 REQUEST_TIMEOUT = 30.0  # seconds — per-request timeout for normal operations
@@ -444,6 +446,57 @@ def _version_key(name: str) -> tuple[int, ...]:
     return tuple(parts)
 
 
+def _module_snapshot_path(module_uri: str) -> Path:
+    """Return the path for the persistent snapshot file for *module_uri*.
+
+    Snapshots live under ``~/.cache/jdtls-snapshots/`` — separate from the
+    jdtls data-dir tree so they survive version-bump cache wipes.
+    Each module gets a 12-char BLAKE2b subdirectory (6-byte digest).
+    """
+    h = hashlib.blake2b(module_uri.encode(), digest_size=6).hexdigest()
+    return Path.home() / ".cache" / "jdtls-snapshots" / h / ".snapshot.json"
+
+
+def _compute_module_diff(
+    module_uri: str,
+) -> tuple[TreeDiff | None, ModuleSnapshot] | None:
+    """Blocking: build current snapshot and diff against stored one.
+
+    Returns ``(diff, current_snapshot)`` or ``None`` on error / size limit.
+    ``diff`` is ``None`` when there is no stored snapshot (first session) or
+    the snapshots are identical — the caller should still save the snapshot in
+    both cases.
+
+    Intended to run inside a thread-pool executor.
+    """
+    from pygls.uris import to_fs_path
+
+    module_fs = to_fs_path(module_uri)
+    if not module_fs:
+        return None
+    module_root = Path(module_fs)
+    if not module_root.is_dir():
+        return None
+
+    current = ModuleSnapshot.build(module_root)
+    if current is None:
+        return None  # file count exceeded limit
+
+    snapshot_path = _module_snapshot_path(module_uri)
+    stored = ModuleSnapshot.load(snapshot_path)
+
+    if stored is None:
+        # First session: persist the baseline and signal "nothing to do yet".
+        try:
+            current.save(snapshot_path)
+        except OSError as exc:
+            logger.warning("merkle: could not save initial snapshot: %s", exc)
+        return (None, current)
+
+    diff = stored.diff(current)
+    return (diff, current)
+
+
 def _clear_cache_on_version_change(cache_root: Path) -> None:
     """Clear jdtls data cache when the server version changes.
 
@@ -534,6 +587,12 @@ class JdtlsProxy:
         self.modules = ModuleRegistry()
         self.has_lombok = False
         self._workspace_expanded = False
+        # Merkle snapshot diff: module_uri → (diff | None, current_snapshot)
+        # Populated by _kick_module_diff (background task on add_module_if_new).
+        # Consumed by server._apply_module_diff after module reaches READY.
+        self._pending_module_data: dict[str, tuple[TreeDiff | None, ModuleSnapshot]] = {}
+        # Background tasks created by this proxy (prevents GC of fire-and-forget tasks).
+        self._proxy_bg_tasks: set[asyncio.Task[Any]] = set()
 
     @property
     def is_available(self) -> bool:
@@ -726,6 +785,17 @@ class JdtlsProxy:
         for method, params in queue:
             await self.send_notification(method, params)
 
+    async def _kick_module_diff(self, module_uri: str) -> None:
+        """Background task: compute snapshot diff and stash it for later use."""
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(None, _compute_module_diff, module_uri)
+        if result is not None:
+            self._pending_module_data[module_uri] = result
+
+    def pop_module_data(self, module_uri: str) -> tuple[TreeDiff | None, ModuleSnapshot] | None:
+        """Pop and return stashed ``(diff, snapshot)`` for *module_uri*, or ``None``."""
+        return self._pending_module_data.pop(module_uri, None)
+
     async def add_module_if_new(self, file_uri: str) -> str | None:
         """Add the module containing *file_uri* to jdtls if not already added.
 
@@ -751,6 +821,12 @@ class JdtlsProxy:
             _WORKSPACE_DID_CHANGE_FOLDERS,
             {"event": {"added": [{"uri": module_uri, "name": mod_name}], "removed": []}},
         )
+        # Fire-and-forget: compute snapshot diff in background so it is ready
+        # when the module reaches READY state.  Does NOT block the jdtls
+        # readiness timeout (which starts ticking at mark_added above).
+        diff_task = asyncio.create_task(self._kick_module_diff(module_uri))
+        self._proxy_bg_tasks.add(diff_task)
+        diff_task.add_done_callback(self._proxy_bg_tasks.discard)
         return module_uri
 
     async def expand_full_workspace(self) -> None:
@@ -791,6 +867,10 @@ class JdtlsProxy:
             self._reader_task.cancel()
         if self._stderr_task and not self._stderr_task.done():
             self._stderr_task.cancel()
+
+        for task in list(self._proxy_bg_tasks):
+            task.cancel()
+        self._proxy_bg_tasks.clear()
 
         if self._process and self._process.returncode is None:
             try:

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -445,6 +445,7 @@ def _version_key(name: str) -> tuple[int, ...]:
     return tuple(parts)
 
 
+@lru_cache(maxsize=256)
 def _module_snapshot_path(module_uri: str) -> Path:
     """Return the path for the persistent snapshot file for *module_uri*.
 
@@ -786,12 +787,19 @@ class JdtlsProxy:
             await self.send_notification(method, params)
 
     async def _kick_module_diff(self, module_uri: str) -> None:
-        """Background task: compute snapshot diff and stash it for later use."""
+        """Background task: compute snapshot diff and stash it for later use.
+
+        Result is stored in ``_module_diff_results`` BEFORE the task is removed
+        from ``_pending_diff_tasks`` to eliminate the TOCTOU window where
+        ``await_module_diff`` could find neither a running task nor a result.
+        """
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(None, _compute_module_diff, module_uri)
-        self._pending_diff_tasks.pop(module_uri, None)
+        # Store result first, then remove from pending — preserves invariant that
+        # once the task is gone from _pending_diff_tasks the result is already readable.
         if result is not None:
             self._module_diff_results[module_uri] = result
+        self._pending_diff_tasks.pop(module_uri, None)
 
     def pop_module_data(self, module_uri: str) -> tuple[TreeDiff | None, ModuleSnapshot] | None:
         """Pop and return stashed ``(diff, snapshot)`` for *module_uri*, or ``None``."""
@@ -803,10 +811,16 @@ class JdtlsProxy:
         Called when the READY signal fires before ``_kick_module_diff`` has
         stored its result — awaiting the task directly avoids a time-based
         sleep and ensures the diff is never silently dropped.
+
+        Swallows ``CancelledError`` so that a ``stop()`` call during the wait
+        does not propagate and crash the caller.
         """
         task = self._pending_diff_tasks.pop(module_uri, None)
         if task is not None and not task.done():
-            await task
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass  # result storage is _kick_module_diff's responsibility
 
     async def add_module_if_new(self, file_uri: str) -> str | None:
         """Add the module containing *file_uri* to jdtls if not already added.

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -871,6 +871,7 @@ class JdtlsProxy:
         for task in list(self._proxy_bg_tasks):
             task.cancel()
         self._proxy_bg_tasks.clear()
+        self._pending_module_data.clear()
 
         if self._process and self._process.returncode is None:
             try:

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -19,7 +19,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from .merkle import ModuleSnapshot, TreeDiff
+from .merkle import _BUILD_FILES, ModuleSnapshot, TreeDiff
 
 logger = logging.getLogger(__name__)
 
@@ -319,7 +319,6 @@ async def read_message(reader: asyncio.StreamReader) -> dict[str, Any] | None:
         return None
 
 
-_BUILD_FILES = ("pom.xml", "build.gradle", "build.gradle.kts")
 _WORKSPACE_DID_CHANGE_FOLDERS = "workspace/didChangeWorkspaceFolders"
 _MAX_QUEUED_NOTIFICATIONS = 200
 _MODULE_READY_TIMEOUT = 30.0
@@ -432,7 +431,7 @@ def _resolve_module_uri(file_uri: str) -> str | None:
     if module_root is None:
         return None
     module_uri = from_fs_path(module_root)
-    return module_uri or None
+    return module_uri if module_uri else None
 
 
 def _version_key(name: str) -> tuple[int, ...]:
@@ -486,11 +485,8 @@ def _compute_module_diff(
     stored = ModuleSnapshot.load(snapshot_path)
 
     if stored is None:
-        # First session: persist the baseline and signal "nothing to do yet".
-        try:
-            current.save(snapshot_path)
-        except OSError as exc:
-            logger.warning("merkle: could not save initial snapshot: %s", exc)
+        # First session: no diff to compute — caller (_apply_module_diff) will
+        # save the baseline snapshot after the module reaches READY.
         return (None, current)
 
     diff = stored.diff(current)
@@ -590,7 +586,11 @@ class JdtlsProxy:
         # Merkle snapshot diff: module_uri → (diff | None, current_snapshot)
         # Populated by _kick_module_diff (background task on add_module_if_new).
         # Consumed by server._apply_module_diff after module reaches READY.
-        self._pending_module_data: dict[str, tuple[TreeDiff | None, ModuleSnapshot]] = {}
+        self._module_diff_results: dict[str, tuple[TreeDiff | None, ModuleSnapshot]] = {}
+        # Task references for in-flight diff computations, keyed by module_uri.
+        # Allows _apply_module_diff to await the task directly if READY fires
+        # before _kick_module_diff stores its result.
+        self._pending_diff_tasks: dict[str, asyncio.Task[None]] = {}
         # Background tasks created by this proxy (prevents GC of fire-and-forget tasks).
         self._proxy_bg_tasks: set[asyncio.Task[Any]] = set()
 
@@ -789,12 +789,24 @@ class JdtlsProxy:
         """Background task: compute snapshot diff and stash it for later use."""
         loop = asyncio.get_running_loop()
         result = await loop.run_in_executor(None, _compute_module_diff, module_uri)
+        self._pending_diff_tasks.pop(module_uri, None)
         if result is not None:
-            self._pending_module_data[module_uri] = result
+            self._module_diff_results[module_uri] = result
 
     def pop_module_data(self, module_uri: str) -> tuple[TreeDiff | None, ModuleSnapshot] | None:
         """Pop and return stashed ``(diff, snapshot)`` for *module_uri*, or ``None``."""
-        return self._pending_module_data.pop(module_uri, None)
+        return self._module_diff_results.pop(module_uri, None)
+
+    async def await_module_diff(self, module_uri: str) -> None:
+        """Wait for the in-flight diff task for *module_uri* to complete, if any.
+
+        Called when the READY signal fires before ``_kick_module_diff`` has
+        stored its result — awaiting the task directly avoids a time-based
+        sleep and ensures the diff is never silently dropped.
+        """
+        task = self._pending_diff_tasks.pop(module_uri, None)
+        if task is not None and not task.done():
+            await task
 
     async def add_module_if_new(self, file_uri: str) -> str | None:
         """Add the module containing *file_uri* to jdtls if not already added.
@@ -827,6 +839,7 @@ class JdtlsProxy:
         diff_task = asyncio.create_task(self._kick_module_diff(module_uri))
         self._proxy_bg_tasks.add(diff_task)
         diff_task.add_done_callback(self._proxy_bg_tasks.discard)
+        self._pending_diff_tasks[module_uri] = diff_task
         return module_uri
 
     async def expand_full_workspace(self) -> None:
@@ -871,7 +884,8 @@ class JdtlsProxy:
         for task in list(self._proxy_bg_tasks):
             task.cancel()
         self._proxy_bg_tasks.clear()
-        self._pending_module_data.clear()
+        self._module_diff_results.clear()
+        self._pending_diff_tasks.clear()
 
         if self._process and self._process.returncode is None:
             try:

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -121,6 +121,12 @@ async def _apply_module_diff(proxy: JdtlsProxy, module_uri: str) -> None:
     """
     data = proxy.pop_module_data(module_uri)
     if data is None:
+        # Race guard: READY may fire before _kick_module_diff finishes (the
+        # filesystem scan is fast but not instantaneous).  Yield once to give
+        # the executor task a chance to complete and store its result.
+        await asyncio.sleep(0.1)
+        data = proxy.pop_module_data(module_uri)
+    if data is None:
         return
     diff, current_snapshot = data
 
@@ -129,13 +135,29 @@ async def _apply_module_diff(proxy: JdtlsProxy, module_uri: str) -> None:
 
         module_fs = to_fs_path(module_uri) or ""
         if module_fs:
-            changed_uris = [uri for rel in diff.all_changed if (uri := from_fs_path(str(Path(module_fs) / rel)))]
-            if changed_uris:
-                changes = [{"uri": u, "type": lsp.FileChangeType.Changed} for u in changed_uris]
+            module_path = Path(module_fs)
+            changes = (
+                [
+                    {"uri": u, "type": lsp.FileChangeType.Created}
+                    for rel in diff.added
+                    if (u := from_fs_path(str(module_path / rel)))
+                ]
+                + [
+                    {"uri": u, "type": lsp.FileChangeType.Changed}
+                    for rel in diff.modified
+                    if (u := from_fs_path(str(module_path / rel)))
+                ]
+                + [
+                    {"uri": u, "type": lsp.FileChangeType.Deleted}
+                    for rel in diff.removed
+                    if (u := from_fs_path(str(module_path / rel)))
+                ]
+            )
+            if changes:
                 await proxy.send_notification("workspace/didChangeWatchedFiles", {"changes": changes})
                 logger.info(
                     "merkle: notified jdtls of %d externally changed file(s) in module",
-                    len(changed_uris),
+                    len(changes),
                 )
 
     # Always persist the current snapshot so next session has an up-to-date baseline.
@@ -387,7 +409,7 @@ def on_initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
 
 
 @server.feature(lsp.INITIALIZED)
-async def on_initialized(params: lsp.InitializedParams) -> None:
+async def on_initialized(_params: lsp.InitializedParams) -> None:
     """Check jdtls availability; actual start deferred to first didOpen."""
     logger.info(
         "java-functional-lsp initialized (rules: %s)",
@@ -591,20 +613,6 @@ async def _lazy_start_jdtls(file_uri: str) -> None:
             await server._proxy.flush_queued_notifications()
     except Exception:
         logger.warning("jdtls lazy start failed", exc_info=True)
-
-
-async def _expand_workspace_background() -> None:
-    """Background task: expand jdtls workspace to full monorepo root.
-
-    Runs after jdtls finishes initializing with the first module scope.
-    The user's actively-opened modules are loaded immediately via
-    ``add_module_if_new()`` in ``on_did_open``; this adds the full root
-    so cross-module references for unopened files also work.
-    """
-    try:
-        await server._proxy.expand_full_workspace()
-    except Exception:
-        logger.warning("Failed to expand jdtls workspace", exc_info=True)
 
 
 # --- jdtls passthrough handlers (registered dynamically, NOT at module level) ---

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import sys
+from collections.abc import Coroutine
 from pathlib import Path
 from typing import Any
 
@@ -91,9 +92,7 @@ class JavaFunctionalLspServer(LanguageServer):
         if module_uri:
             self._proxy.modules.mark_ready(module_uri)
             # Fire-and-forget: apply Merkle diff and save updated snapshot.
-            task = asyncio.create_task(_apply_module_diff(self._proxy, module_uri))
-            _bg_tasks.add(task)
-            task.add_done_callback(_bg_tasks.discard)
+            _fire_and_forget(_apply_module_diff(self._proxy, module_uri))
         try:
             _analyze_and_publish(uri)
         except Exception as e:
@@ -109,6 +108,13 @@ _bg_tasks: set[asyncio.Task[None]] = set()
 _DEBOUNCE_SECONDS = 0.15
 
 
+def _fire_and_forget(coro: Coroutine[Any, Any, Any]) -> None:
+    """Schedule *coro* as a background task, preventing GC until it finishes."""
+    task = asyncio.create_task(coro)
+    _bg_tasks.add(task)
+    task.add_done_callback(_bg_tasks.discard)
+
+
 async def _apply_module_diff(proxy: JdtlsProxy, module_uri: str) -> None:
     """Send ``workspace/didChangeWatchedFiles`` for externally changed files.
 
@@ -121,16 +127,15 @@ async def _apply_module_diff(proxy: JdtlsProxy, module_uri: str) -> None:
     """
     data = proxy.pop_module_data(module_uri)
     if data is None:
-        # Race guard: READY may fire before _kick_module_diff finishes (the
-        # filesystem scan is fast but not instantaneous).  Yield once to give
-        # the executor task a chance to complete and store its result.
-        await asyncio.sleep(0.1)
+        # Race guard: READY may fire before _kick_module_diff finishes.
+        # Await the in-flight task directly (no arbitrary sleep).
+        await proxy.await_module_diff(module_uri)
         data = proxy.pop_module_data(module_uri)
     if data is None:
         return
     diff, current_snapshot = data
 
-    if diff and not diff.is_empty:
+    if diff is not None and not diff.is_empty:
         from pygls.uris import from_fs_path, to_fs_path
 
         module_fs = to_fs_path(module_uri) or ""
@@ -518,9 +523,7 @@ def _forward_or_queue(method: str, serialized: Any) -> None:
     if server._skip_jdtls:
         return
     if server._proxy.is_available:
-        task = asyncio.create_task(server._proxy.send_notification(method, serialized))
-        _bg_tasks.add(task)
-        task.add_done_callback(_bg_tasks.discard)
+        _fire_and_forget(server._proxy.send_notification(method, serialized))
     elif server._proxy._lazy_start_fired and not server._proxy._start_failed:
         server._proxy.queue_notification(method, serialized)
 
@@ -550,9 +553,7 @@ async def on_did_open(params: lsp.DidOpenTextDocumentParams) -> None:
         if not server._proxy._lazy_start_fired:
             # First file: kick off lazy start in background.
             server._proxy._lazy_start_fired = True
-            task = asyncio.create_task(_lazy_start_jdtls(uri))
-            _bg_tasks.add(task)
-            task.add_done_callback(_bg_tasks.discard)
+            _fire_and_forget(_lazy_start_jdtls(uri))
 
     # Custom diagnostics always publish immediately — never blocked by jdtls.
     try:

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -28,7 +28,7 @@ from .analyzers.mutation_checker import MutationChecker
 from .analyzers.null_checker import NullChecker
 from .analyzers.spring_checker import SpringChecker
 from .fixes import get_fix, get_fix_registry_keys
-from .proxy import JdtlsProxy, _resolve_module_uri
+from .proxy import JdtlsProxy, _module_snapshot_path, _resolve_module_uri
 
 logger = logging.getLogger(__name__)
 
@@ -75,18 +75,25 @@ class JavaFunctionalLspServer(LanguageServer):
         self._skip_jdtls_registration: bool = False
         self._init_generation: int = 0
 
-    def _on_jdtls_diagnostics(self, uri: str, diagnostics: list[Any]) -> None:
+    def _on_jdtls_diagnostics(self, uri: str, _diagnostics: list[Any]) -> None:
         """Called when jdtls publishes diagnostics — merge with custom and re-publish.
 
         Also marks the file's module as READY, since receiving diagnostics from
         jdtls is a reliable signal that the module has been indexed (more reliable
         than a first non-None response which may be semantically empty).
+
+        When a module transitions to READY, fires ``_apply_module_diff`` to
+        notify jdtls about any externally changed files (e.g., after git pull).
         """
         if not uri.endswith(".java"):
             return
         module_uri = _resolve_module_uri(uri)
         if module_uri:
             self._proxy.modules.mark_ready(module_uri)
+            # Fire-and-forget: apply Merkle diff and save updated snapshot.
+            task = asyncio.create_task(_apply_module_diff(self._proxy, module_uri))
+            _bg_tasks.add(task)
+            task.add_done_callback(_bg_tasks.discard)
         try:
             _analyze_and_publish(uri)
         except Exception as e:
@@ -100,6 +107,44 @@ _pending: dict[str, asyncio.Task[None]] = {}
 # Background tasks (prevent GC of fire-and-forget tasks)
 _bg_tasks: set[asyncio.Task[None]] = set()
 _DEBOUNCE_SECONDS = 0.15
+
+
+async def _apply_module_diff(proxy: JdtlsProxy, module_uri: str) -> None:
+    """Send ``workspace/didChangeWatchedFiles`` for externally changed files.
+
+    Called (fire-and-forget) when a module reaches READY state.  Pops the
+    ``(diff, snapshot)`` pair computed by ``_kick_module_diff`` during module
+    registration, notifies jdtls about changed files so it can do an
+    incremental rebuild, then persists the updated snapshot to disk.
+
+    No-ops if the diff computation is not yet finished or found no changes.
+    """
+    data = proxy.pop_module_data(module_uri)
+    if data is None:
+        return
+    diff, current_snapshot = data
+
+    if diff and not diff.is_empty:
+        from pygls.uris import from_fs_path, to_fs_path
+
+        module_fs = to_fs_path(module_uri) or ""
+        if module_fs:
+            changed_uris = [uri for rel in diff.all_changed if (uri := from_fs_path(str(Path(module_fs) / rel)))]
+            if changed_uris:
+                changes = [{"uri": u, "type": lsp.FileChangeType.Changed} for u in changed_uris]
+                await proxy.send_notification("workspace/didChangeWatchedFiles", {"changes": changes})
+                logger.info(
+                    "merkle: notified jdtls of %d externally changed file(s) in module",
+                    len(changed_uris),
+                )
+
+    # Always persist the current snapshot so next session has an up-to-date baseline.
+    snapshot_path = _module_snapshot_path(module_uri)
+    loop = asyncio.get_running_loop()
+    try:
+        await loop.run_in_executor(None, current_snapshot.save, snapshot_path)
+    except OSError as exc:
+        logger.warning("merkle: could not save updated snapshot: %s", exc)
 
 
 def _handle_exception(exc_type: type[BaseException], exc_value: BaseException, exc_tb: Any) -> None:

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -90,9 +90,12 @@ class JavaFunctionalLspServer(LanguageServer):
             return
         module_uri = _resolve_module_uri(uri)
         if module_uri:
+            already_ready = self._proxy.modules.is_ready(module_uri)
             self._proxy.modules.mark_ready(module_uri)
-            # Fire-and-forget: apply Merkle diff and save updated snapshot.
-            _fire_and_forget(_apply_module_diff(self._proxy, module_uri))
+            if not already_ready:
+                # First READY transition only — subsequent diagnostics for the same
+                # module are no-ops to avoid spawning O(files) redundant tasks.
+                _fire_and_forget(_apply_module_diff(self._proxy, module_uri))
         try:
             _analyze_and_publish(uri)
         except Exception as e:

--- a/tests/test_merkle.py
+++ b/tests/test_merkle.py
@@ -1,0 +1,290 @@
+"""Tests for merkle.ModuleSnapshot and TreeDiff."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from java_functional_lsp.merkle import (
+    _BUILD_FILES,
+    ModuleSnapshot,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def write(path: Path, content: str = "class Foo {}") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# ModuleSnapshot.build
+# ---------------------------------------------------------------------------
+
+
+class TestModuleSnapshotBuild:
+    def test_empty_module(self, tmp_path: Path) -> None:
+        snap = ModuleSnapshot.build(tmp_path)
+        assert snap is not None
+        assert snap.files == {}
+
+    def test_tracks_java_files(self, tmp_path: Path) -> None:
+        write(tmp_path / "src" / "Foo.java", "class Foo {}")
+        write(tmp_path / "src" / "Bar.java", "class Bar {}")
+        snap = ModuleSnapshot.build(tmp_path)
+        assert snap is not None
+        assert "src/Foo.java" in snap.files
+        assert "src/Bar.java" in snap.files
+
+    def test_tracks_build_files(self, tmp_path: Path) -> None:
+        write(tmp_path / "pom.xml", "<project/>")
+        write(tmp_path / "build.gradle", "apply plugin: 'java'")
+        snap = ModuleSnapshot.build(tmp_path)
+        assert snap is not None
+        assert "pom.xml" in snap.files
+        assert "build.gradle" in snap.files
+
+    def test_ignores_non_tracked_files(self, tmp_path: Path) -> None:
+        write(tmp_path / "README.md", "# readme")
+        write(tmp_path / "src" / "Foo.class", b"\xca\xfe\xba\xbe".decode("latin-1"))
+        snap = ModuleSnapshot.build(tmp_path)
+        assert snap is not None
+        assert all(f.endswith(".java") or Path(f).name in _BUILD_FILES for f in snap.files)
+
+    def test_skips_target_directory(self, tmp_path: Path) -> None:
+        write(tmp_path / "src" / "Main.java")
+        write(tmp_path / "target" / "classes" / "Main.java")
+        snap = ModuleSnapshot.build(tmp_path)
+        assert snap is not None
+        assert "src/Main.java" in snap.files
+        assert not any("target" in f for f in snap.files)
+
+    def test_skips_git_directory(self, tmp_path: Path) -> None:
+        write(tmp_path / ".git" / "hooks" / "pre-commit.java")
+        write(tmp_path / "src" / "App.java")
+        snap = ModuleSnapshot.build(tmp_path)
+        assert snap is not None
+        assert "src/App.java" in snap.files
+        assert not any(".git" in f for f in snap.files)
+
+    def test_skips_node_modules(self, tmp_path: Path) -> None:
+        write(tmp_path / "node_modules" / "pkg" / "Foo.java")
+        write(tmp_path / "src" / "App.java")
+        snap = ModuleSnapshot.build(tmp_path)
+        assert snap is not None
+        assert not any("node_modules" in f for f in snap.files)
+
+    def test_skips_symlinks(self, tmp_path: Path) -> None:
+        real = write(tmp_path / "Real.java")
+        link = tmp_path / "Link.java"
+        link.symlink_to(real)
+        snap = ModuleSnapshot.build(tmp_path)
+        assert snap is not None
+        assert "Real.java" in snap.files
+        assert "Link.java" not in snap.files
+
+    def test_root_hash_stable(self, tmp_path: Path) -> None:
+        write(tmp_path / "Foo.java")
+        snap1 = ModuleSnapshot.build(tmp_path)
+        snap2 = ModuleSnapshot.build(tmp_path)
+        assert snap1 is not None
+        assert snap2 is not None
+        assert snap1.root_hash == snap2.root_hash
+
+    def test_root_hash_changes_on_content_change(self, tmp_path: Path) -> None:
+        f = write(tmp_path / "Foo.java", "class Foo {}")
+        snap1 = ModuleSnapshot.build(tmp_path)
+        f.write_text("class Foo { int x; }")
+        snap2 = ModuleSnapshot.build(tmp_path)
+        assert snap1 is not None
+        assert snap2 is not None
+        assert snap1.root_hash != snap2.root_hash
+
+    def test_returns_none_above_file_count_limit(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Patch the limit to 2 to avoid creating thousands of files.
+        import java_functional_lsp.merkle as merkle_mod
+
+        monkeypatch.setattr(merkle_mod, "_MAX_FILES", 2)
+        for i in range(3):
+            write(tmp_path / f"Cls{i}.java")
+        result = ModuleSnapshot.build(tmp_path)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TreeDiff
+# ---------------------------------------------------------------------------
+
+
+class TestTreeDiff:
+    def _snap(self, files: dict[str, str]) -> ModuleSnapshot:
+        root_input = "\n".join(f"{p}:{h}" for p, h in sorted(files.items()))
+        import hashlib
+
+        root_hash = hashlib.blake2b(root_input.encode(), digest_size=32).hexdigest()
+        return ModuleSnapshot(root_hash=root_hash, files=files)
+
+    def test_empty_diff_when_identical(self) -> None:
+        snap = self._snap({"Foo.java": "aaa"})
+        diff = snap.diff(snap)
+        assert diff.is_empty
+
+    def test_added_file(self) -> None:
+        old = self._snap({"Foo.java": "aaa"})
+        new = self._snap({"Foo.java": "aaa", "Bar.java": "bbb"})
+        diff = old.diff(new)
+        assert "Bar.java" in diff.added
+        assert diff.modified == frozenset()
+        assert diff.removed == frozenset()
+
+    def test_modified_file(self) -> None:
+        old = self._snap({"Foo.java": "aaa"})
+        new = self._snap({"Foo.java": "bbb"})
+        diff = old.diff(new)
+        assert "Foo.java" in diff.modified
+        assert diff.added == frozenset()
+        assert diff.removed == frozenset()
+
+    def test_removed_file(self) -> None:
+        old = self._snap({"Foo.java": "aaa", "Bar.java": "bbb"})
+        new = self._snap({"Foo.java": "aaa"})
+        diff = old.diff(new)
+        assert "Bar.java" in diff.removed
+        assert diff.added == frozenset()
+        assert diff.modified == frozenset()
+
+    def test_all_changed_excludes_removed(self) -> None:
+        old = self._snap({"Foo.java": "aaa", "Bar.java": "bbb"})
+        new = self._snap({"Baz.java": "ccc"})
+        diff = old.diff(new)
+        assert "Baz.java" in diff.all_changed
+        assert "Bar.java" not in diff.all_changed  # removed, not added/modified
+
+    def test_has_build_file_changes_pom(self) -> None:
+        old = self._snap({"pom.xml": "v1"})
+        new = self._snap({"pom.xml": "v2"})
+        diff = old.diff(new)
+        assert diff.has_build_file_changes
+
+    def test_has_build_file_changes_gradle(self) -> None:
+        old = self._snap({"build.gradle": "v1"})
+        new = self._snap({"build.gradle": "v2"})
+        diff = old.diff(new)
+        assert diff.has_build_file_changes
+
+    def test_has_no_build_file_changes_for_java(self) -> None:
+        old = self._snap({"Foo.java": "v1"})
+        new = self._snap({"Foo.java": "v2"})
+        diff = old.diff(new)
+        assert not diff.has_build_file_changes
+
+
+# ---------------------------------------------------------------------------
+# Save / load roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestModuleSnapshotPersistence:
+    def test_roundtrip(self, tmp_path: Path) -> None:
+        snap = ModuleSnapshot(root_hash="abc123", files={"Foo.java": "hash1", "pom.xml": "hash2"})
+        p = tmp_path / "snap" / ".snapshot.json"
+        snap.save(p)
+        loaded = ModuleSnapshot.load(p)
+        assert loaded is not None
+        assert loaded.root_hash == snap.root_hash
+        assert loaded.files == snap.files
+
+    def test_atomic_write_creates_parent(self, tmp_path: Path) -> None:
+        snap = ModuleSnapshot(root_hash="x", files={})
+        p = tmp_path / "a" / "b" / "c" / ".snapshot.json"
+        snap.save(p)
+        assert p.exists()
+
+    def test_parent_created_with_restricted_permissions(self, tmp_path: Path) -> None:
+        snap = ModuleSnapshot(root_hash="x", files={})
+        snap_dir = tmp_path / "private"
+        p = snap_dir / ".snapshot.json"
+        snap.save(p)
+        mode = oct(os.stat(snap_dir).st_mode)[-3:]
+        assert mode == "700"
+
+    def test_load_missing_returns_none(self, tmp_path: Path) -> None:
+        result = ModuleSnapshot.load(tmp_path / "nonexistent.json")
+        assert result is None
+
+    def test_load_corrupted_json_returns_none(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.json"
+        p.write_text("{not valid json")
+        assert ModuleSnapshot.load(p) is None
+
+    def test_load_rejects_path_traversal(self, tmp_path: Path) -> None:
+        p = tmp_path / "snap.json"
+        data = json.dumps({"root": "x", "files": {"../secret": "hash"}})
+        p.write_text(data)
+        assert ModuleSnapshot.load(p) is None
+
+    def test_load_rejects_absolute_path_key(self, tmp_path: Path) -> None:
+        p = tmp_path / "snap.json"
+        data = json.dumps({"root": "x", "files": {"/etc/passwd": "hash"}})
+        p.write_text(data)
+        assert ModuleSnapshot.load(p) is None
+
+    def test_load_rejects_null_byte_in_key(self, tmp_path: Path) -> None:
+        p = tmp_path / "snap.json"
+        data = json.dumps({"root": "x", "files": {"foo\x00bar": "hash"}})
+        p.write_text(data)
+        assert ModuleSnapshot.load(p) is None
+
+    def test_load_rejects_wrong_types(self, tmp_path: Path) -> None:
+        p = tmp_path / "snap.json"
+        p.write_text(json.dumps({"root": 123, "files": {}}))
+        assert ModuleSnapshot.load(p) is None
+
+    def test_load_rejects_oversized_snapshot(self, tmp_path: Path) -> None:
+        from java_functional_lsp.merkle import _MAX_SNAPSHOT_FILES
+
+        p = tmp_path / "snap.json"
+        big = {f"File{i}.java": "h" for i in range(_MAX_SNAPSHOT_FILES + 1)}
+        p.write_text(json.dumps({"root": "x", "files": big}))
+        assert ModuleSnapshot.load(p) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: build + diff + save + load
+# ---------------------------------------------------------------------------
+
+
+class TestModuleSnapshotIntegration:
+    def test_build_diff_save_load(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "Foo.java").write_text("class Foo {}")
+        (src / "pom.xml").write_text("<project/>")
+
+        snap_path = tmp_path / ".snapshot.json"
+        snap1 = ModuleSnapshot.build(tmp_path)
+        assert snap1 is not None
+        snap1.save(snap_path)
+
+        # Modify one file, add another
+        (src / "Foo.java").write_text("class Foo { int x; }")
+        (src / "Bar.java").write_text("class Bar {}")
+
+        snap2 = ModuleSnapshot.build(tmp_path)
+        assert snap2 is not None
+
+        loaded1 = ModuleSnapshot.load(snap_path)
+        assert loaded1 is not None
+
+        diff = loaded1.diff(snap2)
+        assert "src/Foo.java" in diff.modified
+        assert "src/Bar.java" in diff.added
+        assert diff.removed == frozenset()
+        assert not diff.is_empty

--- a/tests/test_merkle.py
+++ b/tests/test_merkle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -117,6 +118,22 @@ class TestModuleSnapshotBuild:
         result = ModuleSnapshot.build(tmp_path)
         assert result is None
 
+    def test_returns_none_at_exact_file_count_limit(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Exactly _MAX_FILES files succeeds; _MAX_FILES+1 triggers None (boundary check)."""
+        import java_functional_lsp.merkle as merkle_mod
+
+        monkeypatch.setattr(merkle_mod, "_MAX_FILES", 2)
+        # Exactly _MAX_FILES files: should succeed (limit not yet exceeded)
+        for i in range(2):
+            write(tmp_path / f"Cls{i}.java")
+        result_at_limit = ModuleSnapshot.build(tmp_path)
+        assert result_at_limit is not None
+        assert len(result_at_limit.files) == 2
+        # One more file: should now return None
+        write(tmp_path / "Extra.java")
+        result_over_limit = ModuleSnapshot.build(tmp_path)
+        assert result_over_limit is None
+
 
 # ---------------------------------------------------------------------------
 # TreeDiff
@@ -125,11 +142,10 @@ class TestModuleSnapshotBuild:
 
 class TestTreeDiff:
     def _snap(self, files: dict[str, str]) -> ModuleSnapshot:
-        root_input = "\n".join(f"{p}:{h}" for p, h in sorted(files.items()))
-        import hashlib
-
-        root_hash = hashlib.blake2b(root_input.encode(), digest_size=32).hexdigest()
-        return ModuleSnapshot(root_hash=root_hash, files=files)
+        h = hashlib.blake2b(digest_size=32)
+        for p, fh in sorted(files.items()):
+            h.update(f"{p}:{fh}\n".encode())
+        return ModuleSnapshot(root_hash=h.hexdigest(), files=files)
 
     def test_empty_diff_when_identical(self) -> None:
         snap = self._snap({"Foo.java": "aaa"})
@@ -166,6 +182,8 @@ class TestTreeDiff:
         diff = old.diff(new)
         assert "Baz.java" in diff.all_changed
         assert "Bar.java" not in diff.all_changed  # removed, not added/modified
+        assert "Bar.java" in diff.removed
+        assert "Foo.java" in diff.removed
 
     def test_has_build_file_changes_pom(self) -> None:
         old = self._snap({"pom.xml": "v1"})
@@ -176,6 +194,12 @@ class TestTreeDiff:
     def test_has_build_file_changes_gradle(self) -> None:
         old = self._snap({"build.gradle": "v1"})
         new = self._snap({"build.gradle": "v2"})
+        diff = old.diff(new)
+        assert diff.has_build_file_changes
+
+    def test_has_build_file_changes_gradle_kts(self) -> None:
+        old = self._snap({"build.gradle.kts": "v1"})
+        new = self._snap({"build.gradle.kts": "v2"})
         diff = old.diff(new)
         assert diff.has_build_file_changes
 

--- a/tests/test_merkle_proxy.py
+++ b/tests/test_merkle_proxy.py
@@ -1,0 +1,366 @@
+"""Tests for merkle snapshot integration with JdtlsProxy and server._apply_module_diff."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from java_functional_lsp.merkle import ModuleSnapshot, TreeDiff
+from java_functional_lsp.proxy import (
+    _compute_module_diff,
+    _module_snapshot_path,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_snapshot(files: dict[str, str]) -> ModuleSnapshot:
+    h = hashlib.blake2b(digest_size=32)
+    for p, fh in sorted(files.items()):
+        h.update(f"{p}:{fh}\n".encode())
+    return ModuleSnapshot(root_hash=h.hexdigest(), files=files)
+
+
+def _make_diff(
+    added: frozenset[str] | None = None,
+    modified: frozenset[str] | None = None,
+    removed: frozenset[str] | None = None,
+) -> TreeDiff:
+    return TreeDiff(
+        added=added or frozenset(),
+        modified=modified or frozenset(),
+        removed=removed or frozenset(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _module_snapshot_path
+# ---------------------------------------------------------------------------
+
+
+class TestModuleSnapshotPath:
+    def test_returns_path_under_jdtls_snapshots_cache(self) -> None:
+        path = _module_snapshot_path("file:///some/module")
+        assert ".cache/jdtls-snapshots" in str(path)
+        assert path.name == ".snapshot.json"
+
+    def test_different_uris_produce_different_paths(self) -> None:
+        p1 = _module_snapshot_path("file:///module/a")
+        p2 = _module_snapshot_path("file:///module/b")
+        assert p1 != p2
+
+    def test_same_uri_produces_same_path(self) -> None:
+        p1 = _module_snapshot_path("file:///module/stable")
+        p2 = _module_snapshot_path("file:///module/stable")
+        assert p1 == p2
+
+
+# ---------------------------------------------------------------------------
+# _compute_module_diff
+# ---------------------------------------------------------------------------
+
+
+class TestComputeModuleDiff:
+    def test_returns_none_for_invalid_uri(self) -> None:
+        result = _compute_module_diff("")
+        assert result is None
+
+    def test_returns_none_for_nonexistent_directory(self) -> None:
+        result = _compute_module_diff("file:///nonexistent/path/that/does/not/exist")
+        assert result is None
+
+    def test_first_session_returns_none_diff_with_snapshot(self, tmp_path: Path) -> None:
+        """No stored snapshot → diff is None, current snapshot is returned."""
+        (tmp_path / "Foo.java").write_text("class Foo {}")
+        from pygls.uris import from_fs_path
+
+        module_uri = from_fs_path(str(tmp_path))
+        assert module_uri is not None
+        # Ensure no stored snapshot exists
+        snap_path = _module_snapshot_path(module_uri)
+        _module_snapshot_path.cache_clear()
+        snap_path = _module_snapshot_path(module_uri)
+        if snap_path.exists():
+            snap_path.unlink()
+
+        result = _compute_module_diff(module_uri)
+        assert result is not None
+        diff, snapshot = result
+        assert diff is None
+        assert "Foo.java" in snapshot.files
+
+    def test_subsequent_session_detects_changes(self, tmp_path: Path) -> None:
+        """Stored snapshot present → diff reflects filesystem changes."""
+        from pygls.uris import from_fs_path
+
+        foo = tmp_path / "Foo.java"
+        foo.write_text("class Foo {}")
+        module_uri = from_fs_path(str(tmp_path))
+        assert module_uri is not None
+
+        # First run: build and save baseline
+        snap1 = ModuleSnapshot.build(tmp_path)
+        assert snap1 is not None
+        _module_snapshot_path.cache_clear()
+        snap_path = _module_snapshot_path(module_uri)
+        snap1.save(snap_path)
+
+        # Modify a file
+        foo.write_text("class Foo { int x; }")
+        (tmp_path / "Bar.java").write_text("class Bar {}")
+
+        result = _compute_module_diff(module_uri)
+        assert result is not None
+        diff, _ = result
+        assert diff is not None
+        assert "Foo.java" in diff.modified
+        assert "Bar.java" in diff.added
+
+
+# ---------------------------------------------------------------------------
+# JdtlsProxy._kick_module_diff and await_module_diff
+# ---------------------------------------------------------------------------
+
+
+class TestKickModuleDiff:
+    @pytest.mark.asyncio
+    async def test_stores_result_before_removing_task(self) -> None:
+        """Result must be in _module_diff_results before task is removed from _pending_diff_tasks."""
+        from java_functional_lsp.proxy import JdtlsProxy
+
+        proxy = JdtlsProxy(on_diagnostics=lambda *_: None)
+        snapshot = _make_snapshot({"Foo.java": "h1"})
+
+        with patch("java_functional_lsp.proxy._compute_module_diff", return_value=(None, snapshot)):
+            task = asyncio.create_task(proxy._kick_module_diff("file:///mod"))
+            await task
+
+        assert "file:///mod" in proxy._module_diff_results
+        assert "file:///mod" not in proxy._pending_diff_tasks
+
+    @pytest.mark.asyncio
+    async def test_none_result_not_stored(self) -> None:
+        from java_functional_lsp.proxy import JdtlsProxy
+
+        proxy = JdtlsProxy(on_diagnostics=lambda *_: None)
+
+        with patch("java_functional_lsp.proxy._compute_module_diff", return_value=None):
+            await proxy._kick_module_diff("file:///mod")
+
+        assert "file:///mod" not in proxy._module_diff_results
+
+
+class TestAwaitModuleDiff:
+    @pytest.mark.asyncio
+    async def test_awaits_in_flight_task(self) -> None:
+        """await_module_diff waits for the task and result becomes available."""
+        from java_functional_lsp.proxy import JdtlsProxy
+
+        proxy = JdtlsProxy(on_diagnostics=lambda *_: None)
+        snapshot = _make_snapshot({"Foo.java": "h1"})
+
+        # Simulate a slow executor: patch to introduce a tiny delay
+        async def _slow_kick(module_uri: str) -> None:
+            await asyncio.sleep(0)  # yield once
+            proxy._module_diff_results[module_uri] = (None, snapshot)
+            proxy._pending_diff_tasks.pop(module_uri, None)
+
+        task = asyncio.create_task(_slow_kick("file:///mod"))
+        proxy._pending_diff_tasks["file:///mod"] = task  # type: ignore[assignment]
+
+        await proxy.await_module_diff("file:///mod")
+        assert "file:///mod" in proxy._module_diff_results
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_pending_task(self) -> None:
+        from java_functional_lsp.proxy import JdtlsProxy
+
+        proxy = JdtlsProxy(on_diagnostics=lambda *_: None)
+        # Should not raise
+        await proxy.await_module_diff("file:///no-such-module")
+
+    @pytest.mark.asyncio
+    async def test_swallows_cancelled_error(self) -> None:
+        from java_functional_lsp.proxy import JdtlsProxy
+
+        proxy = JdtlsProxy(on_diagnostics=lambda *_: None)
+
+        async def _never() -> None:
+            await asyncio.sleep(9999)
+
+        task = asyncio.create_task(_never())
+        proxy._pending_diff_tasks["file:///mod"] = task  # type: ignore[assignment]
+        task.cancel()
+        await asyncio.sleep(0)  # let cancellation propagate
+
+        # Should not raise
+        await proxy.await_module_diff("file:///mod")
+
+
+# ---------------------------------------------------------------------------
+# server._apply_module_diff
+# ---------------------------------------------------------------------------
+
+
+class _FakeProxy:
+    """Minimal proxy stub for _apply_module_diff tests."""
+
+    def __init__(self, data: tuple[TreeDiff | None, ModuleSnapshot] | None = None) -> None:
+        self._data: dict[str, tuple[TreeDiff | None, ModuleSnapshot] | None] = {}
+        if data is not None:
+            self._data["file:///mod"] = data
+        self.notifications: list[tuple[str, Any]] = []
+        self._awaited = False
+
+    def pop_module_data(self, module_uri: str) -> tuple[TreeDiff | None, ModuleSnapshot] | None:
+        return self._data.pop(module_uri, None)
+
+    async def await_module_diff(self, _: str) -> None:
+        self._awaited = True
+
+    async def send_notification(self, method: str, params: Any) -> None:
+        self.notifications.append((method, params))
+
+
+class TestApplyModuleDiff:
+    @pytest.mark.asyncio
+    async def test_noop_when_no_data(self) -> None:
+        from java_functional_lsp.server import _apply_module_diff
+
+        proxy = _FakeProxy()
+        await _apply_module_diff(proxy, "file:///mod")  # type: ignore[arg-type]
+        assert proxy.notifications == []
+
+    @pytest.mark.asyncio
+    async def test_awaits_task_on_race_then_processes(self) -> None:
+        """If first pop returns None, await_module_diff is called and second pop is tried."""
+        from java_functional_lsp.server import _apply_module_diff
+
+        snapshot = _make_snapshot({"Foo.java": "h1"})
+        proxy = _FakeProxy()
+
+        call_count = 0
+
+        def _pop(_: str) -> tuple[TreeDiff | None, ModuleSnapshot] | None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return None
+            return (None, snapshot)
+
+        proxy.pop_module_data = _pop  # type: ignore[method-assign]
+
+        with patch("java_functional_lsp.server._module_snapshot_path") as mock_path:
+            mock_path.return_value = MagicMock()
+            with patch("asyncio.get_running_loop") as mock_loop:
+                mock_loop.return_value.run_in_executor = AsyncMock(return_value=None)
+                await _apply_module_diff(proxy, "file:///mod")  # type: ignore[arg-type]
+
+        assert proxy._awaited
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_first_session_saves_snapshot_without_notification(self) -> None:
+        """diff=None (first session) → save snapshot, no workspace/didChangeWatchedFiles."""
+        from java_functional_lsp.server import _apply_module_diff
+
+        snapshot = _make_snapshot({"Foo.java": "h1"})
+        proxy = _FakeProxy(data=(None, snapshot))
+
+        with patch("java_functional_lsp.server._module_snapshot_path") as mock_path:
+            mock_path.return_value = MagicMock()
+            with patch("asyncio.get_running_loop") as mock_loop:
+                mock_loop.return_value.run_in_executor = AsyncMock(return_value=None)
+                await _apply_module_diff(proxy, "file:///mod")  # type: ignore[arg-type]
+
+        assert proxy.notifications == []
+        mock_loop.return_value.run_in_executor.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sends_correct_change_types(self) -> None:
+        """Added → Created, modified → Changed, removed → Deleted."""
+        from lsprotocol import types as lsp
+
+        from java_functional_lsp.server import _apply_module_diff
+
+        snapshot = _make_snapshot({"Foo.java": "h1"})
+        diff = _make_diff(
+            added=frozenset(["New.java"]),
+            modified=frozenset(["Foo.java"]),
+            removed=frozenset(["Old.java"]),
+        )
+        proxy = _FakeProxy(data=(diff, snapshot))
+
+        with patch("java_functional_lsp.server._module_snapshot_path") as mock_path:
+            mock_path.return_value = MagicMock()
+            with patch("asyncio.get_running_loop") as mock_loop:
+                mock_loop.return_value.run_in_executor = AsyncMock(return_value=None)
+                with patch("pygls.uris.to_fs_path", return_value="/tmp/mod"):
+                    with patch("pygls.uris.from_fs_path", side_effect=lambda p: f"file://{p}"):
+                        await _apply_module_diff(proxy, "file:///mod")  # type: ignore[arg-type]
+
+        assert len(proxy.notifications) == 1
+        method, params = proxy.notifications[0]
+        assert method == "workspace/didChangeWatchedFiles"
+        changes = params["changes"]
+        types_by_uri = {c["uri"].split("/")[-1]: c["type"] for c in changes}
+        assert types_by_uri["New.java"] == lsp.FileChangeType.Created
+        assert types_by_uri["Foo.java"] == lsp.FileChangeType.Changed
+        assert types_by_uri["Old.java"] == lsp.FileChangeType.Deleted
+
+    @pytest.mark.asyncio
+    async def test_oserror_on_save_logged_not_raised(self) -> None:
+        """OSError during snapshot save is logged and does not propagate."""
+        from java_functional_lsp.server import _apply_module_diff
+
+        snapshot = _make_snapshot({})
+        diff = _make_diff()  # empty diff, no notification
+        proxy = _FakeProxy(data=(diff, snapshot))
+
+        with patch("java_functional_lsp.server._module_snapshot_path") as mock_path:
+            mock_path.return_value = MagicMock()
+            with patch("asyncio.get_running_loop") as mock_loop:
+                mock_loop.return_value.run_in_executor = AsyncMock(side_effect=OSError("disk full"))
+                # Should not raise
+                await _apply_module_diff(proxy, "file:///mod")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _on_jdtls_diagnostics fires _apply_module_diff only on first READY transition
+# ---------------------------------------------------------------------------
+
+
+class TestOnJdtlsDiagnosticsReadyGuard:
+    def test_fires_only_on_first_ready_transition(self) -> None:
+        """_apply_module_diff should be scheduled exactly once per module."""
+        from java_functional_lsp.server import server
+
+        fired_count = 0
+
+        def _fake_fire(coro: Any) -> None:
+            nonlocal fired_count
+            fired_count += 1
+            # Don't actually schedule anything
+
+            coro.close()
+
+        with patch("java_functional_lsp.server._fire_and_forget", side_effect=_fake_fire):
+            with patch("java_functional_lsp.server._analyze_and_publish"):
+                with patch("java_functional_lsp.server._resolve_module_uri", return_value="file:///mod"):
+                    # First call — module is not yet ready
+                    server._proxy.modules._states.pop("file:///mod", None)
+                    server._on_jdtls_diagnostics("file:///Foo.java", [])
+                    first = fired_count
+                    # Second call — module is already READY
+                    server._on_jdtls_diagnostics("file:///Foo.java", [])
+                    second = fired_count
+
+        assert first == 1
+        assert second == 1  # no additional fires

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary

- Adds `ModuleSnapshot` (BLAKE2b file hash snapshot) to detect externally changed Java files between plugin sessions (e.g., after `git pull`)
- On module READY, sends `workspace/didChangeWatchedFiles` for changed files so jdtls performs an incremental rebuild — no more stale diagnostics until the user manually opens each file
- Snapshots stored in `~/.cache/jdtls-snapshots/` (separate from jdtls data-dir, survives version-bump cache wipes)
- Snapshot build runs fire-and-forget in thread executor (does not block the jdtls readiness timeout)

## Design highlights

- **Correct LSP mechanism**: `workspace/didChangeWatchedFiles` triggers jdtls's incremental build pipeline including cross-file dependency resolution (not `textDocument/didOpen` which only updates the in-memory buffer)
- **Safety bounds**: skip `target/`, `.git/`, `node_modules/`, `.gradle/`; file-count limit of 20k prevents multi-second stalls on monorepo roots
- **Security**: atomic writes (tempfile + rename), `mode=0o700` on snapshot dir, path traversal validation on load
- **Hash**: BLAKE2b (stdlib, 1.5–2× faster than SHA256, same 256-bit collision resistance)

## Test plan

- [x] 30 new unit tests in `tests/test_merkle.py` (build, diff, save/load, security validation)
- [x] All 417 tests pass, 82% overall coverage
- [ ] Manual: open a module, run `git pull` updating Java sources, restart plugin — verify `workspace/didChangeWatchedFiles` appears in jdtls logs for the changed files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)