### PR TITLE
fix: stop group-root walk before workspace_root to prevent monorepo OOM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.9.3"
+version = "0.9.4"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -465,13 +465,14 @@ def _find_maven_group_root(initial_module: Path, workspace_root: Path) -> Path:
     workspace_root = workspace_root.resolve()
     resolved_module = initial_module.resolve()
     current = resolved_module.parent
-    # Bail immediately if the initial module is outside the workspace.
+    # Case 1: module is outside the workspace entirely — scope to workspace_root
+    # (also fires when initial_module == workspace_root, since parent is then
+    # outside workspace_root).
     if not current.is_relative_to(workspace_root):
         return workspace_root
     # Walk up to (but NOT including) workspace_root.  Inspecting workspace_root's
-    # own pom.xml would include the entire monorepo (e.g. 200+ modules) which
-    # causes OOM.  For flat modules that live directly under workspace_root there
-    # is no intermediate group; fall back to the initial module itself.
+    # own pom.xml would include the entire monorepo (e.g. 200+ modules) → OOM.
+    # `current.parent == current` detects the filesystem root (POSIX `/` or Windows drive).
     while current not in (workspace_root, current.parent):
         pom = current / "pom.xml"
         if pom.is_file():
@@ -481,7 +482,8 @@ def _find_maven_group_root(initial_module: Path, workspace_root: Path) -> Path:
             except OSError:
                 pass
         current = current.parent
-    # No intermediate group found — use the initial module as its own scope.
+    # Case 2: no intermediate group pom found — use the initial module as its own scope
+    # (tightest possible; avoids full-monorepo indexing for flat modules under workspace_root).
     return resolved_module
 
 
@@ -928,8 +930,10 @@ class JdtlsProxy:
         Maven parent.  This covers sibling modules (the common case for
         cross-module navigation) without ballooning the index.
 
-        Falls back to the full IDE workspace root when no intermediate
-        multi-module parent is found.
+        Falls back to the initial module itself when no intermediate
+        multi-module parent is found (e.g. flat modules sitting directly
+        under the workspace root), keeping the jdtls scope as tight as
+        possible.
 
         Removes all individually-added module folders to avoid double-indexing
         with the newly added group root.

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -448,12 +448,12 @@ def _version_key(name: str) -> tuple[int, ...]:
 def _find_maven_group_root(initial_module: Path, workspace_root: Path) -> Path:
     """Return the tightest Maven multi-module parent of *initial_module*.
 
-    Walks up from ``initial_module.parent`` (the module itself is skipped —
-    we want its *parent* group, not the module's own pom) toward (and
-    including) ``workspace_root``, returning the first ancestor whose
-    ``pom.xml`` contains a ``<modules>`` section.  Falls back to
-    ``workspace_root`` when no such intermediate parent exists (e.g. flat
-    single-level monorepos).
+    Walks up from ``initial_module.parent`` toward (but NOT including)
+    ``workspace_root``, returning the first ancestor whose ``pom.xml``
+    contains a ``<modules>`` section.  Falls back to ``initial_module``
+    itself when no intermediate group pom exists (e.g. modules that sit
+    directly under ``workspace_root``), keeping the scope as tight as
+    possible and avoiding accidental full-monorepo indexing.
 
     This keeps the jdtls index bounded to a module *group* (typically
     5-20 modules) rather than the full IDE workspace (potentially 200+ modules)
@@ -463,11 +463,16 @@ def _find_maven_group_root(initial_module: Path, workspace_root: Path) -> Path:
     before walking to avoid symlink-based boundary escapes.
     """
     workspace_root = workspace_root.resolve()
-    current = initial_module.resolve().parent
+    resolved_module = initial_module.resolve()
+    current = resolved_module.parent
     # Bail immediately if the initial module is outside the workspace.
     if not current.is_relative_to(workspace_root):
         return workspace_root
-    while True:
+    # Walk up to (but NOT including) workspace_root.  Inspecting workspace_root's
+    # own pom.xml would include the entire monorepo (e.g. 200+ modules) which
+    # causes OOM.  For flat modules that live directly under workspace_root there
+    # is no intermediate group; fall back to the initial module itself.
+    while current not in (workspace_root, current.parent):
         pom = current / "pom.xml"
         if pom.is_file():
             try:
@@ -475,10 +480,9 @@ def _find_maven_group_root(initial_module: Path, workspace_root: Path) -> Path:
                     return current
             except OSError:
                 pass
-        if current in (workspace_root, current.parent):
-            break
         current = current.parent
-    return workspace_root
+    # No intermediate group found — use the initial module as its own scope.
+    return resolved_module
 
 
 @lru_cache(maxsize=256)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1131,17 +1131,24 @@ class TestLazyStart:
         assert event["added"][0]["uri"] == group.as_uri()
         assert event["added"][0]["uri"] != workspace_uri
 
-    async def test_expand_falls_back_to_workspace_root_when_no_group_pom(self, tmp_path: Path) -> None:
-        """Falls back to the IDE workspace root when no intermediate multi-module parent exists."""
+    async def test_expand_noop_for_flat_module_directly_under_workspace(self, tmp_path: Path) -> None:
+        """No notification sent when the initial module IS the group root (flat layout).
+
+        For modules sitting directly under workspace_root with no intermediate group pom,
+        _find_maven_group_root returns the module itself. Since it was already added,
+        expand_full_workspace() is a no-op — which is correct: the scope is already
+        as tight as possible and workspace_root's pom.xml (potentially 200+ modules) is
+        never inspected.
+        """
         from unittest.mock import AsyncMock
 
         from java_functional_lsp.proxy import JdtlsProxy
 
-        # Flat layout: workspace/module — no intermediate pom.xml
+        # Flat layout: workspace/module — no intermediate pom.xml between module and workspace
         workspace = tmp_path / "workspace"
         module = workspace / "module"
         module.mkdir(parents=True)
-        # workspace/pom.xml has <modules>, but there's nothing in between
+        # workspace/pom.xml has <modules>, but the walk stops BEFORE reaching it
         (workspace / "pom.xml").write_text("<project><modules><module>module</module></modules></project>")
 
         module_uri = module.as_uri()
@@ -1155,9 +1162,9 @@ class TestLazyStart:
         proxy.send_notification = AsyncMock()  # type: ignore[assignment]
         await proxy.expand_full_workspace()
 
-        call_args = proxy.send_notification.call_args[0]  # type: ignore[attr-defined]
-        event = call_args[1]["event"]
-        assert event["added"][0]["uri"] == workspace_uri
+        # No notification — module was already added and is already the tightest scope
+        proxy.send_notification.assert_not_called()  # type: ignore[attr-defined]
+        assert proxy._workspace_expanded is True
 
     async def test_expand_full_workspace_sends_notification(self) -> None:
         from unittest.mock import AsyncMock
@@ -1172,28 +1179,43 @@ class TestLazyStart:
         proxy.send_notification.assert_called_once()  # type: ignore[attr-defined]
         assert proxy._workspace_expanded is True
 
-    async def test_expand_full_workspace_removes_initial_module(self) -> None:
-        """All modules in _states (not just _initial_module_uri) are removed on expansion."""
+    async def test_expand_full_workspace_removes_initial_module(self, tmp_path: Path) -> None:
+        """All modules in _states are removed when expanding to an intermediate group root."""
         from unittest.mock import AsyncMock
 
         from java_functional_lsp.proxy import JdtlsProxy
 
+        # Layout: monorepo/group/module-a, monorepo/group/module-b
+        # group/pom.xml has <modules> → group becomes the expansion target
+        monorepo = tmp_path / "monorepo"
+        group = monorepo / "group"
+        module_a = group / "module-a"
+        module_b = group / "module-b"
+        for d in (module_a, module_b):
+            d.mkdir(parents=True)
+        (group / "pom.xml").write_text("<project><modules><module>module-a</module></modules></project>")
+
+        module_a_uri = module_a.as_uri()
+        module_b_uri = module_b.as_uri()
+        monorepo_uri = monorepo.as_uri()
+        group_uri = group.as_uri()
+
         proxy = JdtlsProxy()
         proxy._available = True
-        proxy._original_root_uri = "file:///workspace/monorepo"
-        proxy._initial_module_uri = "file:///workspace/monorepo/module-a"
-        # Simulate that module-a was mark_added during start() and module-b via add_module_if_new
-        proxy.modules.mark_added("file:///workspace/monorepo/module-a")
-        proxy.modules.mark_added("file:///workspace/monorepo/module-b")
+        proxy._original_root_uri = monorepo_uri
+        proxy._initial_module_uri = module_a_uri
+        # Simulate module-a added during start() and module-b via add_module_if_new
+        proxy.modules.mark_added(module_a_uri)
+        proxy.modules.mark_added(module_b_uri)
         proxy.send_notification = AsyncMock()  # type: ignore[assignment]
         await proxy.expand_full_workspace()
         proxy.send_notification.assert_called_once()  # type: ignore[attr-defined]
         call_args = proxy.send_notification.call_args[0]  # type: ignore[attr-defined]
         event = call_args[1]["event"]
         removed_uris = {e["uri"] for e in event["removed"]}
-        assert "file:///workspace/monorepo/module-a" in removed_uris
-        assert "file:///workspace/monorepo/module-b" in removed_uris
-        assert event["added"][0]["uri"] == "file:///workspace/monorepo"
+        assert module_a_uri in removed_uris
+        assert module_b_uri in removed_uris
+        assert event["added"][0]["uri"] == group_uri
 
     async def test_expand_full_workspace_noop_when_not_available(self) -> None:
         from unittest.mock import AsyncMock

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1132,13 +1132,13 @@ class TestLazyStart:
         assert event["added"][0]["uri"] != workspace_uri
 
     async def test_expand_noop_for_flat_module_directly_under_workspace(self, tmp_path: Path) -> None:
-        """No notification sent when the initial module IS the group root (flat layout).
+        """No notification sent for flat modules sitting directly under workspace_root.
 
-        For modules sitting directly under workspace_root with no intermediate group pom,
-        _find_maven_group_root returns the module itself. Since it was already added,
-        expand_full_workspace() is a no-op — which is correct: the scope is already
-        as tight as possible and workspace_root's pom.xml (potentially 200+ modules) is
-        never inspected.
+        When there is no intermediate group pom between the module and workspace_root,
+        _find_maven_group_root returns the module itself (not workspace_root). Since the
+        module was already added, expand_full_workspace() is a no-op — which is correct:
+        the scope is already as tight as possible and workspace_root's pom.xml
+        (potentially 200+ modules → OOM) is never inspected.
         """
         from unittest.mock import AsyncMock
 


### PR DESCRIPTION
## Summary

- Flat modules (e.g. `products/related-content`) sit directly under the workspace root. The walk previously checked `workspace_root/pom.xml` first, found `<modules>` (248 entries), and expanded jdtls to the entire monorepo → OOM.
- The walk now stops **before** `workspace_root`. When no intermediate group pom is found, falls back to the initial module itself (tightest possible scope).
- Nested modules (e.g. `editorial-management/core-engine`) still correctly find the nearest group parent.

**Expansion by module type (after fix):**
| Module | Expands to | Modules indexed |
|--------|-----------|-----------------|
| `products/related-content` | `related-content/` | 1 (was: 248 → OOM) |
| `products/editorial-management/em-core-engine` | `editorial-management/` | ~17 |
| `products/search-engine/search-engine-qna` | `search-engine/` | ~12 |

## Test plan
- [x] `TestFindMavenGroupRoot` — unit tests for the walk logic
- [x] `test_expand_noop_for_flat_module_directly_under_workspace` — verifies flat modules don't trigger monorepo expansion
- [x] `test_expand_full_workspace_removes_initial_module` — verifies nested modules expand to correct group root and remove individually-added modules
- [x] All 444 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)