### PR TITLE
debug: add INFO logging to diagnose cross-module null results

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.9.7"
+version = "0.9.8"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.9.7"
+__version__ = "0.9.8"

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -696,12 +696,18 @@ async def _ensure_module_and_forward(
         return None
 
     module_uri = _resolve_module_uri(file_uri)
+    short_mod = Path(to_fs_path(module_uri) or module_uri).name if module_uri else "<none>"
 
     # Hot path: module already confirmed working.
     if module_uri and proxy.modules.is_ready(module_uri):
-        return await proxy.send_request(method, _serialize_params(params))
+        logger.info("jdtls: %s [hot] module=%s", method, short_mod)
+        result = await proxy.send_request(method, _serialize_params(params))
+        if result is None:
+            logger.info("jdtls: %s [hot] → null (jdtls has no result for this file_uri)", method)
+        return result
 
     # Cold path: add module if unknown, then wait for ready.
+    logger.info("jdtls: %s [cold] module=%s expanded=%s", method, short_mod, proxy._workspace_expanded)
     new_module_uri = await proxy.add_module_if_new(file_uri)
 
     serialized = _serialize_params(params)
@@ -719,11 +725,13 @@ async def _ensure_module_and_forward(
     # If a concurrent request succeeds, Event.set() wakes us early.
     wait_uri = new_module_uri or module_uri
     if wait_uri and not proxy.modules.is_ready(wait_uri):
+        logger.info("jdtls: %s [cold] waiting for module %s to become ready", method, short_mod)
         await proxy.modules.wait_until_ready(wait_uri, timeout=5.0)
     # Always retry once after waiting — even on timeout the module may be ready.
     result = await proxy.send_request(method, serialized)
     if result is not None and can_mark_ready and module_uri:
         proxy.modules.mark_ready(module_uri)
+    logger.info("jdtls: %s [cold] retry → %s", method, "result" if result is not None else "null")
     return result
 
 
@@ -803,8 +811,11 @@ async def _on_incoming_calls(
     if result is None:
         return None
     try:
-        return [_converter.structure(c, lsp.CallHierarchyIncomingCall) for c in result]
-    except Exception:
+        structured = [_converter.structure(c, lsp.CallHierarchyIncomingCall) for c in result]
+        logger.info("jdtls: incomingCalls → %d callers", len(structured))
+        return structured
+    except Exception as e:
+        logger.warning("jdtls: incomingCalls structuring failed: %s (raw=%r)", e, result)
         return None
 
 


### PR DESCRIPTION
## Summary

- Logs `method`, hot/cold path, module name, and retry outcome at INFO level in `_ensure_module_and_forward`
- Logs caller count for `incomingCalls` successes and structuring failures with raw result

## Purpose

Diagnostic release to identify exactly which LSP methods return null for cross-module navigation and whether jdtls itself returns null or our proxy is at fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)