### PR TITLE
fix: defer module READY until jdtls resolves Maven project (code-16 guard)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.9.8"
+version = "0.9.9"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.9.8"
+__version__ = "0.9.9"

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -76,12 +76,17 @@ class JavaFunctionalLspServer(LanguageServer):
         self._skip_jdtls_registration: bool = False
         self._init_generation: int = 0
 
-    def _on_jdtls_diagnostics(self, uri: str, _diagnostics: list[Any]) -> None:
+    def _on_jdtls_diagnostics(self, uri: str, diagnostics: list[Any]) -> None:
         """Called when jdtls publishes diagnostics — merge with custom and re-publish.
 
         Also marks the file's module as READY, since receiving diagnostics from
         jdtls is a reliable signal that the module has been indexed (more reliable
         than a first non-None response which may be semantically empty).
+
+        Exception: if any diagnostic carries ``_JDTLS_NON_PROJECT_CODE`` (code 16),
+        jdtls has opened the file but hasn't resolved its Maven project yet — only
+        syntax errors are available.  We skip the READY transition and wait for the
+        follow-up publish (after Maven import completes) that arrives without code 16.
 
         When a module transitions to READY, fires ``_apply_module_diff`` to
         notify jdtls about any externally changed files (e.g., after git pull).
@@ -90,6 +95,12 @@ class JavaFunctionalLspServer(LanguageServer):
             return
         module_uri = _resolve_module_uri(uri)
         if module_uri:
+            is_non_project = any(
+                str(d.get("code", "")) == _JDTLS_NON_PROJECT_CODE for d in diagnostics if isinstance(d, dict)
+            )
+            if is_non_project:
+                logger.info("jdtls: skipping READY for %s (non-project file, Maven import pending)", Path(uri).name)
+                return
             already_ready = self._proxy.modules.is_ready(module_uri)
             self._proxy.modules.mark_ready(module_uri)
             if not already_ready:
@@ -419,7 +430,7 @@ def on_initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
 
 
 @server.feature(lsp.INITIALIZED)
-async def on_initialized(_params: lsp.InitializedParams) -> None:
+async def on_initialized(_: lsp.InitializedParams) -> None:
     """Check jdtls availability; actual start deferred to first didOpen."""
     logger.info(
         "java-functional-lsp initialized (rules: %s)",
@@ -671,6 +682,12 @@ _LIGHTWEIGHT_METHODS: frozenset[str] = frozenset(
         "textDocument/documentSymbol",
     }
 )
+
+# jdtls diagnostic code for files it opened but hasn't resolved into a Maven project yet.
+# When this appears in a publishDiagnostics batch, jdtls has syntax info only — no classpath,
+# no cross-file resolution.  We must NOT mark the module READY yet; wait for a re-publish
+# without code 16 (after Maven project import finishes).
+_JDTLS_NON_PROJECT_CODE: str = "16"
 
 
 async def _ensure_module_and_forward(

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -100,13 +100,13 @@ class JavaFunctionalLspServer(LanguageServer):
             )
             if is_non_project:
                 logger.info("jdtls: skipping READY for %s (non-project file, Maven import pending)", Path(uri).name)
-                return
-            already_ready = self._proxy.modules.is_ready(module_uri)
-            self._proxy.modules.mark_ready(module_uri)
-            if not already_ready:
-                # First READY transition only — subsequent diagnostics for the same
-                # module are no-ops to avoid spawning O(files) redundant tasks.
-                _fire_and_forget(_apply_module_diff(self._proxy, module_uri))
+            else:
+                already_ready = self._proxy.modules.is_ready(module_uri)
+                self._proxy.modules.mark_ready(module_uri)
+                if not already_ready:
+                    # First READY transition only — subsequent diagnostics for the same
+                    # module are no-ops to avoid spawning O(files) redundant tasks.
+                    _fire_and_forget(_apply_module_diff(self._proxy, module_uri))
         try:
             _analyze_and_publish(uri)
         except FileNotFoundError:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -290,6 +290,48 @@ class TestServerInternals:
         finally:
             server.workspace.remove_text_document(uri)
 
+    def test_on_jdtls_diagnostics_non_project_skips_ready(self) -> None:
+        """A publishDiagnostics batch with code-16 must NOT mark the module READY."""
+        from java_functional_lsp.proxy import ModuleState
+        from java_functional_lsp.server import server
+
+        server._proxy.modules.clear()
+        uri = "file:///mod/Foo.java"
+        non_project_diag = {
+            "code": "16",
+            "message": "Foo.java is a non-project file, only syntax errors are reported",
+            "source": "Java",
+            "severity": 2,
+            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
+        }
+        server._on_jdtls_diagnostics(uri, [non_project_diag])
+        assert server._proxy.modules.get_state("file:///mod") != ModuleState.READY
+
+    def test_on_jdtls_diagnostics_project_file_marks_ready(self) -> None:
+        """A publishDiagnostics batch without code-16 MUST mark the module READY."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.proxy import ModuleState
+        from java_functional_lsp.server import server
+
+        server._proxy.modules.clear()
+        uri = "file:///mod/Pr.java"
+        real_diag = {
+            "code": "268435844",
+            "message": "Some unused import",
+            "source": "Java",
+            "severity": 2,
+            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
+        }
+        with (
+            patch("java_functional_lsp.server._resolve_module_uri", return_value="file:///mod"),
+            patch("java_functional_lsp.server._analyze_and_publish"),
+            patch("java_functional_lsp.server._fire_and_forget"),
+        ):
+            server._on_jdtls_diagnostics(uri, [real_diag])
+        assert server._proxy.modules.get_state("file:///mod") == ModuleState.READY
+        server._proxy.modules.clear()
+
     def test_init_capabilities_exclude_jdtls_features(self) -> None:
         """Static capabilities must NOT include hover/definition/references/completion/documentSymbol.
 
@@ -541,7 +583,7 @@ class TestServerInternals:
         mock_add = AsyncMock(return_value="file:///mod")
         mock_send = AsyncMock(side_effect=[None, {"result": "ok"}])
 
-        async def mock_wait(uri: str, timeout: float = 30.0) -> bool:  # pyright: ignore[reportUnusedParameter]
+        async def mock_wait(uri: str, timeout: float = 30.0) -> bool:  # type: ignore[reportUnusedParameter]
             srv._proxy.modules.mark_ready(uri)
             return True
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -292,6 +292,8 @@ class TestServerInternals:
 
     def test_on_jdtls_diagnostics_non_project_skips_ready(self) -> None:
         """A publishDiagnostics batch with code-16 must NOT mark the module READY."""
+        from unittest.mock import patch
+
         from java_functional_lsp.proxy import ModuleState
         from java_functional_lsp.server import server
 
@@ -304,7 +306,11 @@ class TestServerInternals:
             "severity": 2,
             "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
         }
-        server._on_jdtls_diagnostics(uri, [non_project_diag])
+        with (
+            patch("java_functional_lsp.server._resolve_module_uri", return_value="file:///mod"),
+            patch("java_functional_lsp.server._analyze_and_publish"),
+        ):
+            server._on_jdtls_diagnostics(uri, [non_project_diag])
         assert server._proxy.modules.get_state("file:///mod") != ModuleState.READY
 
     def test_on_jdtls_diagnostics_project_file_marks_ready(self) -> None:


### PR DESCRIPTION
## Summary

- **Root cause found**: `_on_jdtls_diagnostics` was marking a module READY as soon as ANY diagnostic arrived from jdtls — including code-16 `"non-project file, only syntax errors are reported"` diagnostics that jdtls emits *before* it has loaded the Maven classpath for a newly-added workspace folder
- **Effect**: cross-file `textDocument/definition` and other requests went on the hot path immediately, jdtls returned `null` because the classpath wasn't loaded yet → cross-module navigation silently failed
- **Fix**: detect `code == "16"` in the incoming diagnostic batch; skip the READY transition and log a message. The module stays UNKNOWN/ADDED until jdtls re-publishes without code 16 (after Maven import completes), at which point `wait_until_ready` wakes up and the retry succeeds

Also cleans up two pre-existing Pyright warnings in touched files.

## Test plan

- [ ] `test_on_jdtls_diagnostics_non_project_skips_ready` — code-16 batch does not mark READY
- [ ] `test_on_jdtls_diagnostics_project_file_marks_ready` — normal batch marks READY
- [ ] Full suite: `uv run pytest` → 475 passed, 83.58% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)