### PR TITLE
feat: cross-Maven-group workspace expansion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.9.9"
+version = "0.9.10"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.9.9"
+__version__ = "0.9.10"

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -375,6 +375,10 @@ class ModuleRegistry:
         if event is not None:
             event.set()
 
+    def uris(self) -> list[str]:
+        """Return all tracked module URIs (any state)."""
+        return list(self._states)
+
     def clear(self) -> None:
         """Reset all state. Used by tests."""
         self._states.clear()
@@ -932,20 +936,20 @@ class JdtlsProxy:
             )
             return None
 
-        # Mark individual module ADDED before await — prevents duplicate sends.
-        self.modules.mark_added(module_uri)
-
         # Remove individually-added child modules within this group to avoid
-        # double-indexing once the group root covers them.
-        group_fs = to_fs_path(group_uri) or group_uri
+        # double-indexing once the group root covers them.  Must run BEFORE
+        # mark_added so we don't remove the module we're about to add.
+        group_path = Path(to_fs_path(group_uri) or group_uri)
         removed: list[dict[str, str]] = []
-        for uri in list(self.modules._states):
+        for uri in self.modules.uris():
             if uri == group_uri:
                 continue
-            p = to_fs_path(uri) or uri
-            if p.startswith(group_fs):
-                removed.append({"uri": uri, "name": Path(p).name})
+            p = Path(to_fs_path(uri) or uri)
+            if p == group_path or p.is_relative_to(group_path):
+                removed.append({"uri": uri, "name": p.name})
 
+        # Mark ADDED before await — atomic in asyncio, prevents duplicate sends.
+        self.modules.mark_added(module_uri)
         self.modules.mark_added(group_uri)
         self._expanded_groups.add(group_uri)
 
@@ -996,14 +1000,17 @@ class JdtlsProxy:
             return
         self.modules.mark_added(root_uri)
 
-        # Remove ALL individually-added modules to prevent double-indexing with
-        # the full root.  This covers both the initial scoped module and any
-        # modules added by add_module_if_new during the ensure_started window.
+        # Remove individually-added modules that are children of the new root.
+        # This covers the initial scoped module and any modules added by
+        # add_module_if_new during the ensure_started window.
+        root_path_obj = Path(root_path)
         removed: list[dict[str, str]] = []
-        for uri in list(self.modules._states):
-            if uri != root_uri:
-                p = to_fs_path(uri) or uri
-                removed.append({"uri": uri, "name": Path(p).name})
+        for uri in self.modules.uris():
+            if uri == root_uri:
+                continue
+            p = Path(to_fs_path(uri) or uri)
+            if p == root_path_obj or p.is_relative_to(root_path_obj):
+                removed.append({"uri": uri, "name": p.name})
 
         logger.info("jdtls: expanding workspace to module group %s", _redact_path(root_path))
         await self.send_notification(

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -28,6 +28,7 @@ _INITIALIZE_TIMEOUT = 120.0  # seconds — module-scoped init can still be slow 
 _START_RETRY_COOLDOWN = 300.0  # seconds — retry jdtls startup after transient failure
 DEFAULT_JVM_MAX_HEAP = "4g"
 _STDERR_LINE_MAX = 1000
+_MAX_EXPANDED_GROUPS: int = 5  # hard cap on concurrent Maven group workspace folders (prevents jdtls OOM)
 
 #: Minimum Java major version required by jdtls 1.57+. Anything below this
 #: is rejected by the jdtls Python launcher with ``"jdtls requires at least
@@ -445,6 +446,7 @@ def _version_key(name: str) -> tuple[int, ...]:
     return tuple(parts)
 
 
+@lru_cache(maxsize=64)
 def _find_maven_group_root(initial_module: Path, workspace_root: Path) -> Path:
     """Return the tightest Maven multi-module parent of *initial_module*.
 
@@ -641,7 +643,7 @@ class JdtlsProxy:
         self._initial_module_uri: str | None = None
         self.modules = ModuleRegistry()
         self.has_lombok = False
-        self._workspace_expanded = False
+        self._expanded_groups: set[str] = set()
         # Merkle snapshot diff: module_uri → (diff | None, current_snapshot)
         # Populated by _kick_module_diff (background task on add_module_if_new).
         # Consumed by server._apply_module_diff after module reaches READY.
@@ -887,33 +889,76 @@ class JdtlsProxy:
                 pass  # result storage is _kick_module_diff's responsibility
 
     async def add_module_if_new(self, file_uri: str) -> str | None:
-        """Add the module containing *file_uri* to jdtls if not already added.
+        """Add the module's Maven group to jdtls if not already expanded.
 
-        Returns the module URI if a new module was added (UNKNOWN → ADDED),
-        or ``None`` if already known or unavailable. The returned URI can be
-        used with ``modules.wait_until_ready()`` for adaptive waiting.
+        When the user navigates to a file in a new Maven group, we add the
+        group root (not the individual module) as a workspace folder.  This
+        gives jdtls the full Maven classpath for cross-module navigation
+        within that group.
 
-        Calls ``modules.mark_added()`` before any ``await`` to prevent
-        duplicate add calls from concurrent coroutines.
+        Returns the module URI if a new group was expanded (for use with
+        ``modules.wait_until_ready()``), or ``None`` if already covered.
+
+        Capped at ``_MAX_EXPANDED_GROUPS`` to prevent jdtls OOM.
         """
-        if not self._available or self._workspace_expanded:
+        if not self._available:
             return None
+        from pygls.uris import from_fs_path, to_fs_path
+
         module_uri = _resolve_module_uri(file_uri)
         if module_uri is None or self.modules.was_added(module_uri):
             return None
-        # Mark ADDED before await — atomic in asyncio, prevents duplicate sends.
-        self.modules.mark_added(module_uri)
-        from pygls.uris import to_fs_path
 
-        logger.info("jdtls: adding module %s", _redact_path(to_fs_path(module_uri)))
-        mod_name = Path(to_fs_path(module_uri) or module_uri).name
+        # Resolve the Maven group root for this module.
+        module_path = to_fs_path(module_uri)
+        workspace_path = to_fs_path(self._original_root_uri) if self._original_root_uri else None
+        if module_path and workspace_path:
+            group_root = _find_maven_group_root(Path(module_path), Path(workspace_path))
+            group_uri = from_fs_path(str(group_root)) or module_uri
+        else:
+            group_uri = module_uri
+
+        # Already expanded this group — module is covered, nothing to do.
+        if group_uri in self._expanded_groups:
+            return None
+
+        # Hard cap: refuse expansion beyond the limit.
+        if len(self._expanded_groups) >= _MAX_EXPANDED_GROUPS:
+            logger.warning(
+                "jdtls: refusing to expand group for %s — %d groups already expanded (max %d). Restart IDE to reset.",
+                Path(module_path or module_uri).name,
+                len(self._expanded_groups),
+                _MAX_EXPANDED_GROUPS,
+            )
+            return None
+
+        # Mark individual module ADDED before await — prevents duplicate sends.
+        self.modules.mark_added(module_uri)
+
+        # Remove individually-added child modules within this group to avoid
+        # double-indexing once the group root covers them.
+        group_fs = to_fs_path(group_uri) or group_uri
+        removed: list[dict[str, str]] = []
+        for uri in list(self.modules._states):
+            if uri == group_uri:
+                continue
+            p = to_fs_path(uri) or uri
+            if p.startswith(group_fs):
+                removed.append({"uri": uri, "name": Path(p).name})
+
+        self.modules.mark_added(group_uri)
+        self._expanded_groups.add(group_uri)
+
+        group_name = Path(to_fs_path(group_uri) or group_uri).name
+        logger.info(
+            "jdtls: expanding to group %s (group %d/%d)", group_name, len(self._expanded_groups), _MAX_EXPANDED_GROUPS
+        )
         await self.send_notification(
             _WORKSPACE_DID_CHANGE_FOLDERS,
-            {"event": {"added": [{"uri": module_uri, "name": mod_name}], "removed": []}},
+            {"event": {"added": [{"uri": group_uri, "name": group_name}], "removed": removed}},
         )
-        # Fire-and-forget: compute snapshot diff in background so it is ready
-        # when the module reaches READY state.  Does NOT block the jdtls
-        # readiness timeout (which starts ticking at mark_added above).
+
+        # Fire-and-forget: compute snapshot diff in background.
         diff_task = asyncio.create_task(self._kick_module_diff(module_uri))
         self._proxy_bg_tasks.add(diff_task)
         diff_task.add_done_callback(self._proxy_bg_tasks.discard)
@@ -921,24 +966,16 @@ class JdtlsProxy:
         return module_uri
 
     async def expand_full_workspace(self) -> None:
-        """Expand jdtls workspace to the nearest Maven module-group root.
+        """Expand jdtls workspace to the initial module's Maven group root.
 
-        Instead of expanding all the way to the IDE workspace root (which may
-        contain hundreds of Maven modules and cause jdtls OOM), this walks up
-        from the initial module to find the *nearest* ancestor directory whose
-        ``pom.xml`` declares ``<modules>`` — i.e. the tightest multi-module
-        Maven parent.  This covers sibling modules (the common case for
-        cross-module navigation) without ballooning the index.
-
-        Falls back to the initial module itself when no intermediate
-        multi-module parent is found (e.g. flat modules sitting directly
-        under the workspace root), keeping the jdtls scope as tight as
-        possible.
+        Called once during lazy start.  Subsequent groups are expanded
+        on-demand by ``add_module_if_new()`` as the user navigates to
+        files in other Maven groups.
 
         Removes all individually-added module folders to avoid double-indexing
         with the newly added group root.
         """
-        if self._workspace_expanded or not self._available or not self._original_root_uri:
+        if not self._available or not self._original_root_uri:
             return
         from pygls.uris import from_fs_path, to_fs_path
 
@@ -952,8 +989,10 @@ class JdtlsProxy:
 
         root_path = group_root_path
         root_uri = from_fs_path(root_path) or self._original_root_uri
-        if self.modules.was_added(root_uri):
-            self._workspace_expanded = True
+
+        # Already expanded (e.g. initial module IS the group root, or called twice).
+        if root_uri in self._expanded_groups or self.modules.was_added(root_uri):
+            self._expanded_groups.add(root_uri)
             return
         self.modules.mark_added(root_uri)
 
@@ -971,7 +1010,7 @@ class JdtlsProxy:
             _WORKSPACE_DID_CHANGE_FOLDERS,
             {"event": {"added": [{"uri": root_uri, "name": Path(root_path).name}], "removed": removed}},
         )
-        self._workspace_expanded = True
+        self._expanded_groups.add(root_uri)
 
     async def stop(self) -> None:
         """Shutdown jdtls subprocess gracefully."""

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -724,7 +724,7 @@ async def _ensure_module_and_forward(
         return result
 
     # Cold path: add module if unknown, then wait for ready.
-    logger.info("jdtls: %s [cold] module=%s expanded=%s", method, short_mod, proxy._workspace_expanded)
+    logger.info("jdtls: %s [cold] module=%s groups=%d", method, short_mod, len(proxy._expanded_groups))
     new_module_uri = await proxy.add_module_if_new(file_uri)
 
     serialized = _serialize_params(params)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1164,7 +1164,7 @@ class TestLazyStart:
 
         # No notification — module was already added and is already the tightest scope
         proxy.send_notification.assert_not_called()  # type: ignore[attr-defined]
-        assert proxy._workspace_expanded is True
+        assert len(proxy._expanded_groups) > 0
 
     async def test_expand_full_workspace_sends_notification(self) -> None:
         from unittest.mock import AsyncMock
@@ -1177,7 +1177,7 @@ class TestLazyStart:
         proxy.send_notification = AsyncMock()  # type: ignore[assignment]
         await proxy.expand_full_workspace()
         proxy.send_notification.assert_called_once()  # type: ignore[attr-defined]
-        assert proxy._workspace_expanded is True
+        assert len(proxy._expanded_groups) > 0
 
     async def test_expand_full_workspace_removes_initial_module(self, tmp_path: Path) -> None:
         """All modules in _states are removed when expanding to an intermediate group root."""
@@ -1227,7 +1227,7 @@ class TestLazyStart:
         proxy.send_notification = AsyncMock()  # type: ignore[assignment]
         await proxy.expand_full_workspace()
         proxy.send_notification.assert_not_called()  # type: ignore[attr-defined]
-        assert proxy._workspace_expanded is False
+        assert len(proxy._expanded_groups) == 0
 
     async def test_expand_full_workspace_noop_when_already_added(self) -> None:
         from unittest.mock import AsyncMock
@@ -1241,7 +1241,108 @@ class TestLazyStart:
         proxy.send_notification = AsyncMock()  # type: ignore[assignment]
         await proxy.expand_full_workspace()
         proxy.send_notification.assert_not_called()  # type: ignore[attr-defined]
-        assert proxy._workspace_expanded is True
+        assert len(proxy._expanded_groups) > 0
+
+    async def test_add_module_cross_group_expands_new_group(self, tmp_path: Path) -> None:
+        """Navigating to a file in a different Maven group expands that group."""
+        from unittest.mock import AsyncMock
+
+        from java_functional_lsp.proxy import JdtlsProxy
+
+        # Layout: monorepo/group-a/mod-a, monorepo/group-b/mod-b
+        monorepo = tmp_path / "monorepo"
+        group_a = monorepo / "group-a"
+        mod_a = group_a / "mod-a"
+        group_b = monorepo / "group-b"
+        mod_b = group_b / "mod-b"
+        for d in (mod_a, mod_b):
+            d.mkdir(parents=True)
+            (d / "pom.xml").write_text("<project/>")
+        (group_a / "pom.xml").write_text("<project><modules><module>mod-a</module></modules></project>")
+        (group_b / "pom.xml").write_text("<project><modules><module>mod-b</module></modules></project>")
+
+        proxy = JdtlsProxy()
+        proxy._available = True
+        proxy._original_root_uri = monorepo.as_uri()
+        proxy._initial_module_uri = mod_a.as_uri()
+        proxy._expanded_groups.add(group_a.as_uri())  # simulate initial expansion done
+        proxy.modules.mark_added(mod_a.as_uri())
+        proxy.send_notification = AsyncMock()  # type: ignore[assignment]
+
+        file_uri = (mod_b / "src" / "Foo.java").as_uri()
+        # Create the file so _resolve_module_uri can find mod-b's pom.xml
+        (mod_b / "src").mkdir()
+        (mod_b / "src" / "Foo.java").touch()
+
+        result = await proxy.add_module_if_new(file_uri)
+        assert result is not None  # module_uri returned for wait_until_ready
+        proxy.send_notification.assert_called_once()  # type: ignore[attr-defined]
+        call_args = proxy.send_notification.call_args[0]  # type: ignore[attr-defined]
+        event = call_args[1]["event"]
+        assert event["added"][0]["uri"] == group_b.as_uri()
+        assert group_b.as_uri() in proxy._expanded_groups
+        assert len(proxy._expanded_groups) == 2
+
+    async def test_add_module_within_expanded_group_is_noop(self, tmp_path: Path) -> None:
+        """A file within an already-expanded group returns None."""
+        from unittest.mock import AsyncMock
+
+        from java_functional_lsp.proxy import JdtlsProxy
+
+        monorepo = tmp_path / "monorepo"
+        group = monorepo / "group"
+        mod_a = group / "mod-a"
+        mod_b = group / "mod-b"
+        for d in (mod_a, mod_b):
+            d.mkdir(parents=True)
+            (d / "pom.xml").write_text("<project/>")
+        (group / "pom.xml").write_text(
+            "<project><modules><module>mod-a</module><module>mod-b</module></modules></project>"
+        )
+
+        proxy = JdtlsProxy()
+        proxy._available = True
+        proxy._original_root_uri = monorepo.as_uri()
+        proxy._expanded_groups.add(group.as_uri())
+        proxy.send_notification = AsyncMock()  # type: ignore[assignment]
+
+        file_uri = (mod_b / "src" / "Bar.java").as_uri()
+        (mod_b / "src").mkdir()
+        (mod_b / "src" / "Bar.java").touch()
+
+        result = await proxy.add_module_if_new(file_uri)
+        assert result is None
+        proxy.send_notification.assert_not_called()  # type: ignore[attr-defined]
+
+    async def test_add_module_at_cap_refuses_expansion(self, tmp_path: Path) -> None:
+        """Expansion is refused when _MAX_EXPANDED_GROUPS is reached."""
+        from unittest.mock import AsyncMock
+
+        from java_functional_lsp.proxy import _MAX_EXPANDED_GROUPS, JdtlsProxy
+
+        monorepo = tmp_path / "monorepo"
+        new_group = monorepo / "new-group"
+        mod = new_group / "mod"
+        mod.mkdir(parents=True)
+        (mod / "pom.xml").write_text("<project/>")
+        (new_group / "pom.xml").write_text("<project><modules><module>mod</module></modules></project>")
+
+        proxy = JdtlsProxy()
+        proxy._available = True
+        proxy._original_root_uri = monorepo.as_uri()
+        # Fill up to the cap with dummy groups
+        for i in range(_MAX_EXPANDED_GROUPS):
+            proxy._expanded_groups.add(f"file:///fake/group-{i}")
+        proxy.send_notification = AsyncMock()  # type: ignore[assignment]
+
+        file_uri = (mod / "src" / "Baz.java").as_uri()
+        (mod / "src").mkdir()
+        (mod / "src" / "Baz.java").touch()
+
+        result = await proxy.add_module_if_new(file_uri)
+        assert result is None
+        proxy.send_notification.assert_not_called()  # type: ignore[attr-defined]
+        assert len(proxy._expanded_groups) == _MAX_EXPANDED_GROUPS
 
     async def test_ensure_started_no_build_file(self) -> None:
         """ensure_started with no build file should pass module_root_uri=None."""

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -983,6 +983,13 @@ class TestFindModuleRoot:
 class TestLazyStart:
     """Tests for lazy-start proxy features."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_group_root_cache(self) -> None:  # type: ignore[override]
+        """Clear _find_maven_group_root lru_cache between tests."""
+        from java_functional_lsp.proxy import _find_maven_group_root
+
+        _find_maven_group_root.cache_clear()
+
     def test_check_available_true(self) -> None:
         from java_functional_lsp.proxy import JdtlsProxy
 
@@ -1280,6 +1287,7 @@ class TestLazyStart:
         call_args = proxy.send_notification.call_args[0]  # type: ignore[attr-defined]
         event = call_args[1]["event"]
         assert event["added"][0]["uri"] == group_b.as_uri()
+        assert event["removed"] == []  # no child modules to remove from new group
         assert group_b.as_uri() in proxy._expanded_groups
         assert len(proxy._expanded_groups) == 2
 


### PR DESCRIPTION
## Summary

- **Root cause**: `_workspace_expanded = True` permanently blocked `add_module_if_new()` after the initial group expansion. Files from other Maven groups (search-engine/, related-content/) were never added via `didChangeWorkspaceFolders` — jdtls treated them as "non-project files" with no Maven classpath
- **Fix**: Replace `_workspace_expanded: bool` with `_expanded_groups: set[str]`. Each new Maven group is expanded on-demand when the user first navigates to a file in it
- **Safety**: Hard cap of 5 groups (`_MAX_EXPANDED_GROUPS`) prevents jdtls OOM. No LRU eviction (removing folders causes full re-index thrashing). `_find_maven_group_root` cached with `@lru_cache`

## Design review

Reviewed by 4-agent design ensemble (scope, security, scalability, devil's advocate). Key findings addressed:
- Scalability BLOCKING → added hard group cap
- Devil's advocate CONCERNS → documented jdtls multi-folder assumption, no LRU eviction
- Scope/quality → inlined group resolution instead of 3 new abstractions

## Test plan

- [x] `test_add_module_cross_group_expands_new_group` — new group sends didChangeWorkspaceFolders
- [x] `test_add_module_within_expanded_group_is_noop` — files in known group return None
- [x] `test_add_module_at_cap_refuses_expansion` — cap enforced at _MAX_EXPANDED_GROUPS
- [x] 4 existing expand_full_workspace tests updated
- [x] Full suite: 478 passed, 83.73% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)