### PR TITLE
feat: forward didChangeConfiguration + document jdtls settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,37 @@ The server auto-discovers `lombok.jar` from these locations (first match wins):
 3. **Maven cache** — auto-discovered from `~/.m2/repository/org/projectlombok/lombok/`
 4. **Dedicated directory** — `~/.jdtls-libs/lombok.jar`
 
-If Lombok is used in your project but the jar isn't found, the server logs a warning. The jdtls cache is automatically cleared on version upgrade, so adding Lombok support takes effect immediately after `brew upgrade`.
+If Lombok is used in your project but the jar isn't found, the server logs a warning.
+
+### jdtls settings
+
+The server sends Maven/Gradle settings to jdtls at startup via `initializationOptions.settings`. Defaults are optimized for Maven monorepos (Maven enabled, Gradle disabled, build artifact exclusions). Override via `.java-functional-lsp.json`:
+
+```json
+{
+  "jdtls": {
+    "settings": {
+      "java": {
+        "import": {
+          "maven": { "enabled": true },
+          "gradle": { "enabled": true },
+          "exclusions": ["**/node_modules/**", "**/target/**"]
+        },
+        "configuration": { "updateBuildConfiguration": "automatic" },
+        "maven": { "downloadSources": true }
+      }
+    }
+  }
+}
+```
+
+Custom settings fully replace the defaults (no merge). See the [jdtls Preferences reference](https://github.com/eclipse-jdtls/eclipse.jdt.ls/blob/main/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java) for all available keys.
+
+### jdtls cache
+
+The jdtls Eclipse workspace index is cached in `~/.cache/jdtls-data/`. Warm starts (~10-20s) reuse this cache; cold starts (60-120s) rebuild from scratch. The cache is automatically invalidated when jdtls or Java is upgraded, but **not** when java-functional-lsp is upgraded — our Python code changes don't affect the Eclipse index.
+
+To force a clean rebuild: `rm -rf ~/.cache/jdtls-data/`
 
 ### Suppressing jdtls diagnostics
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.9.11"
+version = "0.9.12"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.9.11"
+__version__ = "0.9.12"

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -635,6 +635,24 @@ async def on_did_close(params: lsp.DidCloseTextDocumentParams) -> None:
     _forward_or_queue("textDocument/didClose", _serialize_params(params))
 
 
+_DIDCHANGE_CONFIG_COOLDOWN = 30.0  # seconds — rate-limit didChangeConfiguration forwarding
+_last_config_forward: float = 0.0
+
+
+@server.feature(lsp.WORKSPACE_DID_CHANGE_CONFIGURATION)
+def on_did_change_configuration(params: lsp.DidChangeConfigurationParams) -> None:
+    """Forward IDE configuration changes to jdtls (rate-limited)."""
+    global _last_config_forward
+    if not server._proxy.is_available:
+        return
+    now = __import__("time").monotonic()
+    if now - _last_config_forward < _DIDCHANGE_CONFIG_COOLDOWN:
+        logger.debug("jdtls: throttling didChangeConfiguration (%.0fs cooldown)", _DIDCHANGE_CONFIG_COOLDOWN)
+        return
+    _last_config_forward = now
+    _fire_and_forget(server._proxy.send_notification("workspace/didChangeConfiguration", _serialize_params(params)))
+
+
 async def _lazy_start_jdtls(file_uri: str) -> None:
     """Background task: start jdtls scoped to the module containing *file_uri*.
 

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import sys
+import time
 from collections.abc import Coroutine
 from pathlib import Path
 from typing import Any
@@ -645,7 +646,7 @@ def on_did_change_configuration(params: lsp.DidChangeConfigurationParams) -> Non
     global _last_config_forward
     if not server._proxy.is_available:
         return
-    now = __import__("time").monotonic()
+    now = time.monotonic()
     if now - _last_config_forward < _DIDCHANGE_CONFIG_COOLDOWN:
         logger.debug("jdtls: throttling didChangeConfiguration (%.0fs cooldown)", _DIDCHANGE_CONFIG_COOLDOWN)
         return

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1571,7 +1571,9 @@ class TestDidChangeConfiguration:
         from java_functional_lsp.server import on_did_change_configuration, server
 
         server._proxy._available = True
-        srv_mod._last_config_forward = __import__("time").monotonic()  # just sent
+        import time
+
+        srv_mod._last_config_forward = time.monotonic()  # just sent
         params = lsp.DidChangeConfigurationParams(settings={})
         with patch("java_functional_lsp.server._fire_and_forget") as mock_faf:
             on_did_change_configuration(params)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1547,6 +1547,48 @@ class TestFindLombokJar:
         assert any("does not exist" in r.getMessage() for r in caplog.records)
 
 
+class TestDidChangeConfiguration:
+    """Tests for workspace/didChangeConfiguration forwarding."""
+
+    def test_forwards_to_jdtls_when_available(self) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        import java_functional_lsp.server as srv_mod
+        from java_functional_lsp.server import on_did_change_configuration, server
+
+        srv_mod._last_config_forward = 0.0  # reset cooldown
+        server._proxy._available = True
+        server._proxy.send_notification = AsyncMock()  # type: ignore[assignment]
+        params = lsp.DidChangeConfigurationParams(settings={"java": {"autobuild": {"enabled": True}}})
+        with patch("java_functional_lsp.server._fire_and_forget") as mock_faf:
+            on_did_change_configuration(params)
+            mock_faf.assert_called_once()
+
+    def test_throttled_within_cooldown(self) -> None:
+        from unittest.mock import patch
+
+        import java_functional_lsp.server as srv_mod
+        from java_functional_lsp.server import on_did_change_configuration, server
+
+        server._proxy._available = True
+        srv_mod._last_config_forward = __import__("time").monotonic()  # just sent
+        params = lsp.DidChangeConfigurationParams(settings={})
+        with patch("java_functional_lsp.server._fire_and_forget") as mock_faf:
+            on_did_change_configuration(params)
+            mock_faf.assert_not_called()
+
+    def test_skipped_when_proxy_unavailable(self) -> None:
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import on_did_change_configuration, server
+
+        server._proxy._available = False
+        params = lsp.DidChangeConfigurationParams(settings={})
+        with patch("java_functional_lsp.server._fire_and_forget") as mock_faf:
+            on_did_change_configuration(params)
+            mock_faf.assert_not_called()
+
+
 class TestCacheClear:
     """Tests for _clear_cache_on_version_change() and _compute_cache_marker()."""
 


### PR DESCRIPTION
## Summary

- **Forward `workspace/didChangeConfiguration`** from IDE to jdtls with 30-second rate limiter to prevent cascading rebuilds
- **Document jdtls.settings** in README: config override format, cache behavior, invalidation policy

Closes #67.

## Test plan

- [x] `test_forwards_to_jdtls_when_available` — handler calls send_notification
- [x] `test_throttled_within_cooldown` — second call within 30s is suppressed
- [x] `test_skipped_when_proxy_unavailable` — no-op when jdtls not running
- [x] Full suite: 489 passed, 84.04% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)