### PR TITLE
feat: LRU eviction for jdtls workspace cache (#75)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.9.13"
+version = "0.9.14"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.9.13"
+__version__ = "0.9.14"

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -29,6 +29,7 @@ _START_RETRY_COOLDOWN = 300.0  # seconds — retry jdtls startup after transient
 DEFAULT_JVM_MAX_HEAP = "4g"
 _STDERR_LINE_MAX = 1000
 _MAX_EXPANDED_GROUPS: int = 5  # hard cap on concurrent Maven group workspace folders (prevents jdtls OOM)
+_WORKSPACE_CACHE_MAX_SIZE: int = 10  # default LRU cap — override via {"cache": {"maxWorkspaces": N}}
 
 # Default jdtls initialization settings.  Sent via initializationOptions.settings
 # so they apply BEFORE the Maven import scan (didChangeConfiguration is too late).
@@ -563,6 +564,45 @@ def _compute_module_diff(
     return (diff, current)
 
 
+def _dir_mtime(path: Path) -> float:
+    """Return ``st_mtime`` of *path*, or 0.0 on any OSError."""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _evict_lru_workspaces(cache_root: Path, *, max_size: int = _WORKSPACE_CACHE_MAX_SIZE) -> None:
+    """Evict least-recently-used jdtls workspace directories when count exceeds *max_size*.
+
+    Implements Caffeine's ``maximumSize`` eviction policy for a filesystem cache.
+    Directories are ordered by ``st_mtime`` (last time jdtls wrote to the workspace).
+    The *max_size* most-recently-modified dirs are kept; the rest are removed.
+
+    Dotfile entries (e.g. ``.version``) and non-directory entries are excluded.
+    Runs in the executor thread (``_blocking_startup``) — never blocks the event loop.
+
+    Users can tune the cap via ``.java-functional-lsp.json``:
+    ``{"cache": {"maxWorkspaces": 20}}``
+    """
+    if not cache_root.is_dir():
+        return
+    try:
+        dirs = [d for d in cache_root.iterdir() if d.is_dir() and not d.name.startswith(".")]
+    except OSError as e:
+        logger.warning("jdtls: cannot scan cache root for eviction: %s", e)
+        return
+    if len(dirs) <= max_size:
+        return
+    dirs.sort(key=_dir_mtime, reverse=True)  # newest first
+    for stale in dirs[max_size:]:
+        try:
+            shutil.rmtree(stale)
+            logger.info("jdtls: evicted workspace cache %s (LRU)", stale.name)
+        except OSError as e:
+            logger.warning("jdtls: failed to evict workspace cache %s: %s", stale.name, e)
+
+
 def _wipe_data_dir(data_dir: Path) -> None:
     """Remove *data_dir* so the next jdtls startup gets a clean cold start.
 
@@ -793,6 +833,8 @@ class JdtlsProxy:
 
         def _blocking_startup() -> tuple[dict[str, str], str | None]:
             _clear_cache_on_version_change(cache_root)
+            _max = int((config or {}).get("cache", {}).get("maxWorkspaces", _WORKSPACE_CACHE_MAX_SIZE))
+            _evict_lru_workspaces(cache_root, max_size=_max)
             return build_jdtls_env(), _find_lombok_jar(config)
 
         loop = asyncio.get_running_loop()

--- a/src/java_functional_lsp/proxy.py
+++ b/src/java_functional_lsp/proxy.py
@@ -565,21 +565,63 @@ def _compute_module_diff(
 
 
 def _dir_mtime(path: Path) -> float:
-    """Return ``st_mtime`` of *path*, or 0.0 on any OSError."""
+    """Return ``st_mtime`` of *path*, or ``float('inf')`` on any OSError.
+
+    Returning infinity on error sorts the directory as the *newest* entry,
+    so stat-inaccessible directories are conservatively kept rather than
+    silently evicted.
+    """
     try:
         return path.stat().st_mtime
     except OSError:
-        return 0.0
+        return float("inf")
+
+
+def _parse_max_workspaces(config: Mapping[str, Any] | None) -> int:
+    """Parse and validate ``cache.maxWorkspaces`` from the project config.
+
+    Returns *_WORKSPACE_CACHE_MAX_SIZE* when the key is absent, when the value
+    cannot be converted to ``int``, or when the result is not positive.  Logs a
+    warning in each error case so the user can diagnose the misconfiguration.
+    """
+    raw = (config or {}).get("cache", {}).get("maxWorkspaces")
+    if raw is None:
+        return _WORKSPACE_CACHE_MAX_SIZE
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "jdtls: invalid cache.maxWorkspaces %r — using default %d",
+            raw,
+            _WORKSPACE_CACHE_MAX_SIZE,
+        )
+        return _WORKSPACE_CACHE_MAX_SIZE
+    if value <= 0:
+        logger.warning(
+            "jdtls: cache.maxWorkspaces must be >= 1, got %d — using default %d",
+            value,
+            _WORKSPACE_CACHE_MAX_SIZE,
+        )
+        return _WORKSPACE_CACHE_MAX_SIZE
+    return value
 
 
 def _evict_lru_workspaces(cache_root: Path, *, max_size: int = _WORKSPACE_CACHE_MAX_SIZE) -> None:
     """Evict least-recently-used jdtls workspace directories when count exceeds *max_size*.
 
     Implements Caffeine's ``maximumSize`` eviction policy for a filesystem cache.
-    Directories are ordered by ``st_mtime`` (last time jdtls wrote to the workspace).
-    The *max_size* most-recently-modified dirs are kept; the rest are removed.
+    Directories are ordered by ``st_mtime`` (last modification time), which is a
+    reliable proxy for last-used time because jdtls always writes to its workspace
+    on startup.  On macOS APFS (``noatime`` default) ``atime`` is not updated on
+    reads, so ``mtime`` is used exclusively.
 
-    Dotfile entries (e.g. ``.version``) and non-directory entries are excluded.
+    The *max_size* most-recently-modified real directories are kept; the rest are
+    removed.  Dotfiles (e.g. ``.version``), symlinks, and non-directory entries
+    are excluded from the eviction candidates.
+
+    A directory whose ``stat()`` raises ``OSError`` is treated as the *newest*
+    entry (``float('inf')`` mtime) so it is conservatively kept.
+
     Runs in the executor thread (``_blocking_startup``) — never blocks the event loop.
 
     Users can tune the cap via ``.java-functional-lsp.json``:
@@ -588,7 +630,7 @@ def _evict_lru_workspaces(cache_root: Path, *, max_size: int = _WORKSPACE_CACHE_
     if not cache_root.is_dir():
         return
     try:
-        dirs = [d for d in cache_root.iterdir() if d.is_dir() and not d.name.startswith(".")]
+        dirs = [d for d in cache_root.iterdir() if d.is_dir() and not d.is_symlink() and not d.name.startswith(".")]
     except OSError as e:
         logger.warning("jdtls: cannot scan cache root for eviction: %s", e)
         return
@@ -833,8 +875,8 @@ class JdtlsProxy:
 
         def _blocking_startup() -> tuple[dict[str, str], str | None]:
             _clear_cache_on_version_change(cache_root)
-            _max = int((config or {}).get("cache", {}).get("maxWorkspaces", _WORKSPACE_CACHE_MAX_SIZE))
-            _evict_lru_workspaces(cache_root, max_size=_max)
+            max_workspaces = _parse_max_workspaces(config)
+            _evict_lru_workspaces(cache_root, max_size=max_workspaces)
             return build_jdtls_env(), _find_lombok_jar(config)
 
         loop = asyncio.get_running_loop()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import shutil
 import subprocess
+import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -1511,6 +1513,152 @@ class TestWipeDataDir:
             _wipe_data_dir(data_dir)
             mock_logger.info.assert_called_once()
             mock_logger.warning.assert_not_called()
+
+
+class TestEvictLruWorkspaces:
+    """Tests for _evict_lru_workspaces — count-based LRU eviction of jdtls workspace dirs."""
+
+    @staticmethod
+    def _make_workspace(cache_root: Path, name: str, mtime_age_days: float) -> Path:
+        """Create a fake workspace dir and backdate its mtime."""
+        d = cache_root / name
+        d.mkdir()
+        ts = time.time() - mtime_age_days * 86400.0
+        import os
+
+        os.utime(d, (ts, ts))
+        return d
+
+    def test_noop_on_missing_cache_root(self, tmp_path: Path) -> None:
+        """No error when cache_root does not exist."""
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        _evict_lru_workspaces(tmp_path / "nonexistent", max_size=10)
+        # No exception raised — that is the assertion
+
+    def test_noop_when_at_or_below_max_size(self, tmp_path: Path) -> None:
+        """No eviction when count <= max_size."""
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        d1 = self._make_workspace(tmp_path, "aabbccdd1234", mtime_age_days=5)
+        d2 = self._make_workspace(tmp_path, "1122334455ab", mtime_age_days=3)
+        _evict_lru_workspaces(tmp_path, max_size=2)
+        assert d1.exists()
+        assert d2.exists()
+
+    def test_evicts_oldest_when_over_max_size(self, tmp_path: Path) -> None:
+        """Oldest dirs (lowest mtime) are removed; newest are kept."""
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        oldest = self._make_workspace(tmp_path, "aabbccdd1111", mtime_age_days=10)
+        middle = self._make_workspace(tmp_path, "aabbccdd2222", mtime_age_days=5)
+        newest = self._make_workspace(tmp_path, "aabbccdd3333", mtime_age_days=1)
+        _evict_lru_workspaces(tmp_path, max_size=2)
+        assert not oldest.exists()
+        assert middle.exists()
+        assert newest.exists()
+
+    def test_dotfiles_never_evicted(self, tmp_path: Path) -> None:
+        """.version and other dotfiles are excluded from eviction."""
+        import os
+
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        marker = tmp_path / ".version"
+        marker.write_text("abc|21")
+        old_ts = time.time() - 999 * 86400.0
+        os.utime(marker, (old_ts, old_ts))
+        # max_size=0 would evict everything — dotfiles must still survive
+        _evict_lru_workspaces(tmp_path, max_size=0)
+        assert marker.exists()
+
+    def test_non_directory_entries_ignored(self, tmp_path: Path) -> None:
+        """Plain files in cache_root are never removed."""
+        import os
+
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        stray = tmp_path / "stray.txt"
+        stray.write_text("irrelevant")
+        old_ts = time.time() - 999 * 86400.0
+        os.utime(stray, (old_ts, old_ts))
+        _evict_lru_workspaces(tmp_path, max_size=0)
+        assert stray.exists()
+
+    def test_stat_error_skipped_gracefully(self, tmp_path: Path) -> None:
+        """OSError during stat is skipped; other dirs are still evicted."""
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        self._make_workspace(tmp_path, "aabbccdd1111", mtime_age_days=10)
+        bad_name = "aabbccdd2222"
+        self._make_workspace(tmp_path, bad_name, mtime_age_days=5)
+
+        original_stat = Path.stat
+
+        def patched_stat(self_path: Path, **kw: Any) -> Any:
+            if self_path.name == bad_name:
+                raise OSError("permission denied")
+            return original_stat(self_path, **kw)
+
+        with patch.object(Path, "stat", patched_stat):
+            # good is oldest by mtime; bad errors on stat → treated as mtime=0 (oldest)
+            # max_size=1 → 1 dir evicted; bad gets mtime=0 so it sorts oldest, gets evicted
+            # good also has mtime older than the third hypothetical newest, but here
+            # we just want to confirm no crash and good is processed.
+            _evict_lru_workspaces(tmp_path, max_size=1)
+        # No exception — that is the primary assertion
+
+    def test_rmtree_error_logged_and_continued(self, tmp_path: Path) -> None:
+        """OSError on rmtree emits a warning and continues evicting remaining dirs."""
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        d1 = self._make_workspace(tmp_path, "aabbccdd1111", mtime_age_days=10)
+        self._make_workspace(tmp_path, "aabbccdd2222", mtime_age_days=5)
+        d3 = self._make_workspace(tmp_path, "aabbccdd3333", mtime_age_days=1)
+
+        call_count = 0
+        original_rmtree = shutil.rmtree
+
+        def patched_rmtree(path: Any, **kw: Any) -> None:
+            nonlocal call_count
+            call_count += 1
+            if Path(path).name == d1.name:
+                raise OSError("busy")
+            original_rmtree(path, **kw)
+
+        with patch("java_functional_lsp.proxy.shutil.rmtree", side_effect=patched_rmtree):
+            with patch("java_functional_lsp.proxy.logger") as mock_logger:
+                _evict_lru_workspaces(tmp_path, max_size=1)
+                # Warning for d1 (rmtree failed); info for d2 (evicted successfully)
+                assert mock_logger.warning.call_count >= 1
+                assert mock_logger.info.call_count >= 1
+
+        assert d3.exists()  # newest kept
+
+    def test_logs_info_on_eviction(self, tmp_path: Path) -> None:
+        """Info log is emitted for each evicted workspace dir, including 'LRU'."""
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        self._make_workspace(tmp_path, "aabbccdd1111", mtime_age_days=10)
+        self._make_workspace(tmp_path, "aabbccdd2222", mtime_age_days=1)
+
+        with patch("java_functional_lsp.proxy.logger") as mock_logger:
+            _evict_lru_workspaces(tmp_path, max_size=1)
+
+        info_calls = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("aabbccdd1111" in m and "LRU" in m for m in info_calls)
+
+    def test_max_size_param_respected(self, tmp_path: Path) -> None:
+        """Passing max_size=3 keeps exactly 3 dirs (the 3 newest)."""
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        dirs = [self._make_workspace(tmp_path, f"workspace{i:04d}", mtime_age_days=float(10 - i)) for i in range(6)]
+        _evict_lru_workspaces(tmp_path, max_size=3)
+        surviving = [d for d in dirs if d.exists()]
+        assert len(surviving) == 3
+        # The 3 newest (smallest age = largest mtime) must survive
+        for d in dirs[-3:]:
+            assert d.exists()
 
     def test_wipe_nonexistent_dir_does_not_raise(self, tmp_path: Path) -> None:
         """Calling wipe on a non-existent dir is safe."""

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import shutil
 import subprocess
 import time
@@ -1514,6 +1515,12 @@ class TestWipeDataDir:
             mock_logger.info.assert_called_once()
             mock_logger.warning.assert_not_called()
 
+    def test_wipe_nonexistent_dir_does_not_raise(self, tmp_path: Path) -> None:
+        """Calling wipe on a non-existent dir is safe."""
+        from java_functional_lsp.proxy import _wipe_data_dir
+
+        _wipe_data_dir(tmp_path / "ghost")  # should not raise
+
 
 class TestEvictLruWorkspaces:
     """Tests for _evict_lru_workspaces — count-based LRU eviction of jdtls workspace dirs."""
@@ -1524,8 +1531,6 @@ class TestEvictLruWorkspaces:
         d = cache_root / name
         d.mkdir()
         ts = time.time() - mtime_age_days * 86400.0
-        import os
-
         os.utime(d, (ts, ts))
         return d
 
@@ -1560,8 +1565,6 @@ class TestEvictLruWorkspaces:
 
     def test_dotfiles_never_evicted(self, tmp_path: Path) -> None:
         """.version and other dotfiles are excluded from eviction."""
-        import os
-
         from java_functional_lsp.proxy import _evict_lru_workspaces
 
         marker = tmp_path / ".version"
@@ -1572,10 +1575,19 @@ class TestEvictLruWorkspaces:
         _evict_lru_workspaces(tmp_path, max_size=0)
         assert marker.exists()
 
+    def test_dotdirs_never_evicted(self, tmp_path: Path) -> None:
+        """Dotfile directories (e.g. .hidden/) are excluded from eviction."""
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        hidden_dir = tmp_path / ".hidden"
+        hidden_dir.mkdir()
+        old_ts = time.time() - 999 * 86400.0
+        os.utime(hidden_dir, (old_ts, old_ts))
+        _evict_lru_workspaces(tmp_path, max_size=0)
+        assert hidden_dir.exists()
+
     def test_non_directory_entries_ignored(self, tmp_path: Path) -> None:
         """Plain files in cache_root are never removed."""
-        import os
-
         from java_functional_lsp.proxy import _evict_lru_workspaces
 
         stray = tmp_path / "stray.txt"
@@ -1585,28 +1597,53 @@ class TestEvictLruWorkspaces:
         _evict_lru_workspaces(tmp_path, max_size=0)
         assert stray.exists()
 
-    def test_stat_error_skipped_gracefully(self, tmp_path: Path) -> None:
-        """OSError during stat is skipped; other dirs are still evicted."""
+    def test_symlinks_never_evicted(self, tmp_path: Path) -> None:
+        """Symlinks in cache_root are excluded — shutil.rmtree must not follow them."""
         from java_functional_lsp.proxy import _evict_lru_workspaces
 
-        self._make_workspace(tmp_path, "aabbccdd1111", mtime_age_days=10)
-        bad_name = "aabbccdd2222"
-        self._make_workspace(tmp_path, bad_name, mtime_age_days=5)
+        # Target is a dotdir (excluded from candidates) so it is never evicted.
+        # This prevents the symlink from going dangling during the test.
+        target = tmp_path / ".hidden_target"
+        target.mkdir()
+        link = tmp_path / "aabbccdd1111"
+        link.symlink_to(target)
+        old_ts = time.time() - 999 * 86400.0
+        os.utime(link, (old_ts, old_ts))
+        _evict_lru_workspaces(tmp_path, max_size=0)
+        assert link.exists()  # symlink itself must survive
+        assert target.exists()  # target must not be deleted
 
-        original_stat = Path.stat
+    def test_dir_mtime_returns_inf_on_oserror(self, tmp_path: Path) -> None:
+        """_dir_mtime returns float('inf') when stat() fails — non-zero sentinel."""
+        from java_functional_lsp.proxy import _dir_mtime
 
-        def patched_stat(self_path: Path, **kw: Any) -> Any:
-            if self_path.name == bad_name:
-                raise OSError("permission denied")
-            return original_stat(self_path, **kw)
+        assert _dir_mtime(tmp_path / "nonexistent") == float("inf")
 
-        with patch.object(Path, "stat", patched_stat):
-            # good is oldest by mtime; bad errors on stat → treated as mtime=0 (oldest)
-            # max_size=1 → 1 dir evicted; bad gets mtime=0 so it sorts oldest, gets evicted
-            # good also has mtime older than the third hypothetical newest, but here
-            # we just want to confirm no crash and good is processed.
+    def test_stat_error_conservatively_keeps_dir(self, tmp_path: Path) -> None:
+        """Dir whose _dir_mtime returns inf is sorted as newest — conservatively kept.
+
+        Patching _dir_mtime directly (not Path.stat) avoids interfering with
+        is_dir() which also calls stat() internally.
+        """
+        from java_functional_lsp.proxy import _evict_lru_workspaces
+
+        older = self._make_workspace(tmp_path, "aabbccdd1111", mtime_age_days=10)
+        kept_dir = self._make_workspace(tmp_path, "aabbccdd2222", mtime_age_days=5)
+
+        original_dir_mtime = proxy_mod._dir_mtime
+
+        def patched_dir_mtime(path: Path) -> float:
+            if path.name == kept_dir.name:
+                return float("inf")
+            return original_dir_mtime(path)
+
+        with patch("java_functional_lsp.proxy._dir_mtime", patched_dir_mtime):
+            # kept_dir: _dir_mtime returns inf → sorted as newest → kept
+            # older: mtime=10 days ago → sorted as oldest → evicted
             _evict_lru_workspaces(tmp_path, max_size=1)
-        # No exception — that is the primary assertion
+
+        assert kept_dir.exists()  # conservatively kept (inf mtime)
+        assert not older.exists()  # evicted as the oldest accessible dir
 
     def test_rmtree_error_logged_and_continued(self, tmp_path: Path) -> None:
         """OSError on rmtree emits a warning and continues evicting remaining dirs."""
@@ -1660,8 +1697,58 @@ class TestEvictLruWorkspaces:
         for d in dirs[-3:]:
             assert d.exists()
 
-    def test_wipe_nonexistent_dir_does_not_raise(self, tmp_path: Path) -> None:
-        """Calling wipe on a non-existent dir is safe."""
-        from java_functional_lsp.proxy import _wipe_data_dir
 
-        _wipe_data_dir(tmp_path / "ghost")  # should not raise
+class TestParseMaxWorkspaces:
+    """Tests for _parse_max_workspaces — config validation for the LRU cap."""
+
+    def test_none_config_returns_default(self) -> None:
+        from java_functional_lsp.proxy import _WORKSPACE_CACHE_MAX_SIZE, _parse_max_workspaces
+
+        assert _parse_max_workspaces(None) == _WORKSPACE_CACHE_MAX_SIZE
+
+    def test_empty_config_returns_default(self) -> None:
+        from java_functional_lsp.proxy import _WORKSPACE_CACHE_MAX_SIZE, _parse_max_workspaces
+
+        assert _parse_max_workspaces({}) == _WORKSPACE_CACHE_MAX_SIZE
+
+    def test_missing_cache_key_returns_default(self) -> None:
+        from java_functional_lsp.proxy import _WORKSPACE_CACHE_MAX_SIZE, _parse_max_workspaces
+
+        assert _parse_max_workspaces({"jdtls": {}}) == _WORKSPACE_CACHE_MAX_SIZE
+
+    def test_valid_value_is_returned(self) -> None:
+        from java_functional_lsp.proxy import _parse_max_workspaces
+
+        assert _parse_max_workspaces({"cache": {"maxWorkspaces": 5}}) == 5
+        assert _parse_max_workspaces({"cache": {"maxWorkspaces": 1}}) == 1
+        assert _parse_max_workspaces({"cache": {"maxWorkspaces": 100}}) == 100
+
+    def test_string_integer_is_accepted(self) -> None:
+        """A string that represents a valid integer (e.g. from JSON) is parsed."""
+        from java_functional_lsp.proxy import _parse_max_workspaces
+
+        assert _parse_max_workspaces({"cache": {"maxWorkspaces": "7"}}) == 7
+
+    def test_invalid_string_returns_default_with_warning(self) -> None:
+        from java_functional_lsp.proxy import _WORKSPACE_CACHE_MAX_SIZE, _parse_max_workspaces
+
+        with patch("java_functional_lsp.proxy.logger") as mock_logger:
+            result = _parse_max_workspaces({"cache": {"maxWorkspaces": "bad"}})
+        assert result == _WORKSPACE_CACHE_MAX_SIZE
+        mock_logger.warning.assert_called_once()
+
+    def test_zero_returns_default_with_warning(self) -> None:
+        from java_functional_lsp.proxy import _WORKSPACE_CACHE_MAX_SIZE, _parse_max_workspaces
+
+        with patch("java_functional_lsp.proxy.logger") as mock_logger:
+            result = _parse_max_workspaces({"cache": {"maxWorkspaces": 0}})
+        assert result == _WORKSPACE_CACHE_MAX_SIZE
+        mock_logger.warning.assert_called_once()
+
+    def test_negative_returns_default_with_warning(self) -> None:
+        from java_functional_lsp.proxy import _WORKSPACE_CACHE_MAX_SIZE, _parse_max_workspaces
+
+        with patch("java_functional_lsp.proxy.logger") as mock_logger:
+            result = _parse_max_workspaces({"cache": {"maxWorkspaces": -1}})
+        assert result == _WORKSPACE_CACHE_MAX_SIZE
+        mock_logger.warning.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.9.6"
+version = "0.9.14"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary

- Adds `_evict_lru_workspaces()` — a Caffeine-style `maximumSize` eviction policy for `~/.cache/jdtls-data/`
- Keeps the N most-recently-modified workspace dirs (by `st_mtime`); evicts the rest at startup
- Default cap: 10 dirs, configurable via `.java-functional-lsp.json`: `{"cache": {"maxWorkspaces": N}}`
- Symlinks, dotfiles, and non-directory entries are never touched
- `_dir_mtime` returns `float('inf')` on `OSError` — stat-inaccessible dirs are conservatively kept
- `_parse_max_workspaces()` validates the config value with `try/except` and clamps `<= 0` — invalid values fall back to the default with a warning instead of crashing jdtls startup
- Per-entry `OSError` on `rmtree` is logged and skipped — eviction never aborts mid-run
- Runs in the existing `_blocking_startup` executor thread — no event-loop impact

Fixes #75.

## Test plan

- [x] `uv run pytest tests/test_proxy.py::TestEvictLruWorkspaces tests/test_proxy.py::TestParseMaxWorkspaces -v` — 20 new tests all pass
- [x] `uv run pytest tests/ --no-cov` — 525 tests pass, no regressions
- [x] All 14 CI checks pass (Python 3.10–3.13 × macOS + Ubuntu, integration with jdtls, CodeQL)
- [ ] Manually verify: open 11+ distinct projects, confirm only 10 workspace dirs remain in `~/.cache/jdtls-data/`
- [ ] Verify config override: set `{"cache": {"maxWorkspaces": 3}}` in `.java-functional-lsp.json`, confirm cap is respected
- [ ] Verify invalid config: set `{"cache": {"maxWorkspaces": "bad"}}`, confirm warning is logged and default is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)