### PR TITLE
fix: filter Eclipse/M2E lifecycle markers from jdtls diagnostics

### DIFF
--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -369,6 +369,24 @@ def _jdtls_raw_to_lsp_diagnostics(raw_diagnostics: list[Any]) -> list[lsp.Diagno
 
 _MAX_PATTERN_LENGTH = 500  # Cap regex length to mitigate ReDoS from pathological patterns
 
+_M2E_SOURCES: frozenset[str] = frozenset({"org.eclipse.m2e"})
+_M2E_MESSAGE_PATTERNS: re.Pattern[str] = re.compile(
+    r"Plugin execution not covered by lifecycle configuration"
+    r"|The project cannot be built until its prerequisite"
+    r"|Failed to execute mojo"
+)
+
+
+def _is_m2e_marker(diag: dict[str, Any]) -> bool:
+    """Return True if the diagnostic is an Eclipse/M2E lifecycle marker (not a Java error)."""
+    if str(diag.get("code", "")) == "0":
+        return True
+    if diag.get("source", "") in _M2E_SOURCES:
+        return True
+    if _M2E_MESSAGE_PATTERNS.search(diag.get("message", "")):
+        return True
+    return False
+
 
 def _compile_user_patterns(config: dict[str, Any]) -> list[re.Pattern[str]]:
     """Compile user-defined suppressJdtlsPatterns from config."""
@@ -417,7 +435,7 @@ def _run_analysis(source: str, uri: str) -> list[lsp.Diagnostic]:
     if server._proxy.is_available:
         try:
             raw = server._proxy.get_cached_diagnostics(uri)
-            raw = [d for d in raw if not _is_jdtls_suppressed(d, server._user_suppress_patterns)]
+            raw = [d for d in raw if not _is_m2e_marker(d) and not _is_jdtls_suppressed(d, server._user_suppress_patterns)]
             jdtls_diags = _jdtls_raw_to_lsp_diagnostics(raw)
         except Exception as e:
             logger.warning("jdtls diagnostic processing failed for %s: %s", uri, e)

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -435,7 +435,9 @@ def _run_analysis(source: str, uri: str) -> list[lsp.Diagnostic]:
     if server._proxy.is_available:
         try:
             raw = server._proxy.get_cached_diagnostics(uri)
-            raw = [d for d in raw if not _is_m2e_marker(d) and not _is_jdtls_suppressed(d, server._user_suppress_patterns)]
+            raw = [
+                d for d in raw if not _is_m2e_marker(d) and not _is_jdtls_suppressed(d, server._user_suppress_patterns)
+            ]
             jdtls_diags = _jdtls_raw_to_lsp_diagnostics(raw)
         except Exception as e:
             logger.warning("jdtls diagnostic processing failed for %s: %s", uri, e)

--- a/tests/test_e2e_jdtls.py
+++ b/tests/test_e2e_jdtls.py
@@ -68,6 +68,10 @@ pytestmark = [
 # so a hung jdtls doesn't wedge the suite.
 _E2E_TEST_TIMEOUT_SEC = 120
 _JDTLS_PARSE_WAIT_SEC = 2.5
+# Max wall-clock seconds to poll for a non-empty documentSymbol result.
+# macOS CI runners are slower than Linux; 60s accommodates cold-start variance.
+_JDTLS_SYMBOL_POLL_TIMEOUT_SEC = 60
+_JDTLS_SYMBOL_POLL_INTERVAL_SEC = 1.0
 
 _HELLO_JAVA = """\
 public class Hello {
@@ -260,7 +264,16 @@ class TestJdtlsEndToEnd:
             assert "textDocument" in serialized, f"_serialize_params emitted wrong field names: {serialized.keys()}"
             assert "text_document" not in serialized
 
-            result = await proxy.send_request("textDocument/documentSymbol", serialized)
+            # Poll until jdtls returns a non-empty symbol list or we time out.
+            # A fixed sleep is unreliable on macOS CI where jdtls cold-start
+            # can reach 20s; polling adapts to the actual indexing speed.
+            deadline = asyncio.get_event_loop().time() + _JDTLS_SYMBOL_POLL_TIMEOUT_SEC
+            result = None
+            while asyncio.get_event_loop().time() < deadline:
+                result = await proxy.send_request("textDocument/documentSymbol", serialized)
+                if result:
+                    break
+                await asyncio.sleep(_JDTLS_SYMBOL_POLL_INTERVAL_SEC)
 
         # Primary assertion: jdtls returned something. With a correctly-shaped
         # request, jdtls always returns a list (possibly empty) for a parsable
@@ -274,7 +287,8 @@ class TestJdtlsEndToEnd:
         assert isinstance(result, list)
         # Hello.java declares a top-level class, so we expect at least one symbol.
         assert len(result) > 0, (
-            "jdtls returned an empty symbol list for a file with a top-level class. "
+            "jdtls returned an empty symbol list for a file with a top-level class "
+            f"after polling for {_JDTLS_SYMBOL_POLL_TIMEOUT_SEC}s. "
             "Either jdtls didn't finish parsing or the file wasn't opened correctly."
         )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2257,9 +2257,7 @@ class TestM2EMarkerFilter:
     def test_plugin_execution_message_is_suppressed(self) -> None:
         from java_functional_lsp.server import _is_m2e_marker
 
-        diag = {
-            "message": "Plugin execution not covered by lifecycle configuration: org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run"
-        }
+        diag = {"message": "Plugin execution not covered by lifecycle configuration: maven-antrun-plugin:3.1.0:run"}
         assert _is_m2e_marker(diag) is True
 
     def test_prerequisite_message_is_suppressed(self) -> None:
@@ -2271,7 +2269,7 @@ class TestM2EMarkerFilter:
     def test_failed_mojo_message_is_suppressed(self) -> None:
         from java_functional_lsp.server import _is_m2e_marker
 
-        diag = {"message": "Failed to execute mojo org.apache.maven.plugins:maven-dependency-plugin:3.6.0:copy-dependencies"}
+        diag = {"message": "Failed to execute mojo org.apache.maven.plugins:maven-dependency-plugin:3.6.0"}
         assert _is_m2e_marker(diag) is True
 
     def test_non_project_code_16_is_not_suppressed(self) -> None:
@@ -2298,7 +2296,11 @@ class TestM2EMarkerFilter:
 
         from java_functional_lsp.server import _run_analysis
 
-        m2e_diag = {"code": "0", "source": "org.eclipse.m2e", "message": "Plugin execution not covered by lifecycle configuration: ..."}
+        m2e_diag = {
+            "code": "0",
+            "source": "org.eclipse.m2e",
+            "message": "Plugin execution not covered by lifecycle configuration",
+        }
         real_diag = {
             "code": "50",
             "source": "jdtls",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2234,3 +2234,88 @@ class TestLspLifecycle:
         assert uri in lsp_client._published, "Timed out waiting for updated diagnostics after didChange"  # type: ignore[attr-defined]
         new_diags = lsp_client._published[uri]  # type: ignore[attr-defined]
         assert len(new_diags) == 0, f"Expected zero diagnostics after fixing, got {[d.code for d in new_diags]}"
+
+
+class TestM2EMarkerFilter:
+    """Tests for built-in suppression of Eclipse/M2E lifecycle markers."""
+
+    def test_code_zero_string_is_suppressed(self) -> None:
+        from java_functional_lsp.server import _is_m2e_marker
+
+        assert _is_m2e_marker({"code": "0", "message": "some message"}) is True
+
+    def test_code_zero_int_is_suppressed(self) -> None:
+        from java_functional_lsp.server import _is_m2e_marker
+
+        assert _is_m2e_marker({"code": 0, "message": "some message"}) is True
+
+    def test_m2e_source_is_suppressed(self) -> None:
+        from java_functional_lsp.server import _is_m2e_marker
+
+        assert _is_m2e_marker({"code": "100", "source": "org.eclipse.m2e", "message": "anything"}) is True
+
+    def test_plugin_execution_message_is_suppressed(self) -> None:
+        from java_functional_lsp.server import _is_m2e_marker
+
+        diag = {
+            "message": "Plugin execution not covered by lifecycle configuration: org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run"
+        }
+        assert _is_m2e_marker(diag) is True
+
+    def test_prerequisite_message_is_suppressed(self) -> None:
+        from java_functional_lsp.server import _is_m2e_marker
+
+        diag = {"message": "The project cannot be built until its prerequisite com.example-core is built."}
+        assert _is_m2e_marker(diag) is True
+
+    def test_failed_mojo_message_is_suppressed(self) -> None:
+        from java_functional_lsp.server import _is_m2e_marker
+
+        diag = {"message": "Failed to execute mojo org.apache.maven.plugins:maven-dependency-plugin:3.6.0:copy-dependencies"}
+        assert _is_m2e_marker(diag) is True
+
+    def test_non_project_code_16_is_not_suppressed(self) -> None:
+        """Code 16 (jdtls non-project) must not be caught by the M2E filter."""
+        from java_functional_lsp.server import _is_m2e_marker
+
+        diag = {"code": "16", "source": "jdtls", "message": "File not on the classpath"}
+        assert _is_m2e_marker(diag) is False
+
+    def test_real_java_error_is_not_suppressed(self) -> None:
+        from java_functional_lsp.server import _is_m2e_marker
+
+        diag = {"code": "100", "source": "jdtls", "message": "The method foo() is undefined for the type Bar"}
+        assert _is_m2e_marker(diag) is False
+
+    def test_missing_fields_do_not_raise(self) -> None:
+        from java_functional_lsp.server import _is_m2e_marker
+
+        assert _is_m2e_marker({}) is False
+
+    def test_m2e_marker_excluded_from_run_analysis(self) -> None:
+        """_run_analysis must drop M2E markers from jdtls cached diagnostics."""
+        from unittest.mock import patch
+
+        from java_functional_lsp.server import _run_analysis
+
+        m2e_diag = {"code": "0", "source": "org.eclipse.m2e", "message": "Plugin execution not covered by lifecycle configuration: ..."}
+        real_diag = {
+            "code": "50",
+            "source": "jdtls",
+            "message": "The method foo() is undefined",
+            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 5}},
+            "severity": 1,
+        }
+
+        with patch("java_functional_lsp.server.server") as mock_server:
+            mock_server._proxy.is_available = True
+            mock_server._proxy.get_cached_diagnostics.return_value = [m2e_diag, real_diag]
+            mock_server._user_suppress_patterns = []
+            mock_server._config = {}
+            mock_server._parser = __import__("java_functional_lsp.analyzers.base", fromlist=["get_parser"]).get_parser()
+
+            result = _run_analysis("public class Foo {}", "file:///test/Foo.java")
+
+        codes = [str(d.code) for d in result if d.source == "jdtls"]
+        assert "0" not in codes, "M2E marker (code=0) should be filtered out"
+        assert "50" in codes, "Real jdtls diagnostic should still be present"


### PR DESCRIPTION
## Summary

- Adds `_is_m2e_marker()` predicate with `_M2E_SOURCES` and `_M2E_MESSAGE_PATTERNS` constants to detect Eclipse/M2E lifecycle markers by `code==0`, `source=="org.eclipse.m2e"`, or known message patterns
- Applies the filter in `_run_analysis` alongside existing user-configured `suppressJdtlsPatterns`, so M2E markers are dropped before being forwarded to the client
- Adds `TestM2EMarkerFilter` test class with 10 tests covering all filter paths and an integration test through `_run_analysis`

Closes #73

## Test plan

- [ ] `uv run pytest tests/test_server.py -k TestM2EMarkerFilter -v` — all 10 new tests pass
- [ ] `uv run pytest tests/test_server.py -v` — no regressions in existing tests (124 pass)
- [ ] In a Maven monorepo with M2E markers, confirm they no longer appear in diagnostics per tool call

https://claude.ai/code/session_01Eeuh4JXv128bz9ReEGBeEU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eeuh4JXv128bz9ReEGBeEU)_