### PR TITLE
feat(plugin): register LSP server via plugin.json for auto-start

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,16 @@
 {
   "name": "java-functional-lsp",
   "description": "Java LSP with functional programming rules enforcement — null safety, immutability, no exceptions, Spring best practices. Wraps jdtls for full Java language support.",
-  "version": "0.4.1"
+  "version": "0.4.2",
+  "lspServers": {
+    "java-functional": {
+      "command": "java-functional-lsp",
+      "extensionToLanguage": {
+        ".java": "java"
+      },
+      "startupTimeout": 120000,
+      "restartOnCrash": true,
+      "maxRestarts": 5
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -132,11 +132,16 @@ Or manually add to your Claude Code config:
   "lspServers": {
     "java-functional": {
       "command": "java-functional-lsp",
-      "extensionToLanguage": { ".java": "java" }
+      "extensionToLanguage": { ".java": "java" },
+      "startupTimeout": 120000,
+      "restartOnCrash": true,
+      "maxRestarts": 5
     }
   }
 }
 ```
+
+(`startupTimeout: 120000` accommodates jdtls cold-start; `restartOnCrash` keeps the server alive across session.)
 
 **Alternative: project-level `.lsp.json`** — instead of installing the plugin or editing global config, add a `.lsp.json` file at your project root:
 
@@ -144,7 +149,10 @@ Or manually add to your Claude Code config:
 {
   "java-functional": {
     "command": "java-functional-lsp",
-    "extensionToLanguage": { ".java": "java" }
+    "extensionToLanguage": { ".java": "java" },
+    "startupTimeout": 120000,
+    "restartOnCrash": true,
+    "maxRestarts": 5
   }
 }
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -119,7 +119,7 @@ LSP support requires `ENABLE_LSP_TOOL=1` in `~/.claude/settings.json`:
 
 For containers or CI, add a `.lsp.json` at the project root instead of installing the plugin:
 ```json
-{ "java-functional": { "command": "java-functional-lsp", "extensionToLanguage": { ".java": "java" } } }
+{ "java-functional": { "command": "java-functional-lsp", "extensionToLanguage": { ".java": "java" }, "startupTimeout": 120000, "restartOnCrash": true, "maxRestarts": 5 } }
 ```
 
 To nudge Claude to act on diagnostics, add to your project's `CLAUDE.md`:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -71,10 +71,15 @@ async def lsp_client(tmp_path: Any) -> LanguageClient:  # type: ignore[misc]
 
     # Collect published diagnostics so tests can assert on them.
     client._published: dict[str, list[lsp.Diagnostic]] = {}  # type: ignore[attr-defined]
+    # Per-URI events signalled by on_publish — used by _open_and_wait_for_diagnostics.
+    client._diag_events: dict[str, asyncio.Event] = {}  # type: ignore[attr-defined]
 
     @client.feature(lsp.TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS)
     def on_publish(params: lsp.PublishDiagnosticsParams) -> None:
         client._published[params.uri] = list(params.diagnostics)  # type: ignore[attr-defined]
+        evt = client._diag_events.get(params.uri)  # type: ignore[attr-defined]
+        if evt is not None:
+            evt.set()
 
     await client.start_io(sys.executable, "-m", "java_functional_lsp")
 
@@ -121,10 +126,14 @@ async def _open_and_wait_for_diagnostics(
 ) -> list[lsp.Diagnostic]:
     """Open a document and wait until publishDiagnostics arrives for its URI.
 
-    The server publishes diagnostics asynchronously after didOpen. We poll
-    the client's collected notifications until the URI appears or timeout.
+    The server publishes diagnostics asynchronously after didOpen. We register
+    an asyncio.Event that on_publish signals, then await it with wait_for so the
+    full timeout is always respected — even when the event loop is transiently
+    busy (e.g. jdtls subprocess creation on a slow macOS runner).
     """
     client._published.pop(uri, None)  # type: ignore[attr-defined]
+    event = asyncio.Event()
+    client._diag_events[uri] = event  # type: ignore[attr-defined]
 
     client.text_document_did_open(
         lsp.DidOpenTextDocumentParams(
@@ -137,14 +146,14 @@ async def _open_and_wait_for_diagnostics(
         )
     )
 
-    deadline = asyncio.get_running_loop().time() + timeout
-    while asyncio.get_running_loop().time() < deadline:
-        if uri in client._published:  # type: ignore[attr-defined]
-            return client._published[uri]  # type: ignore[attr-defined]
-        await asyncio.sleep(0.1)
+    try:
+        await asyncio.wait_for(event.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        pytest.fail(f"Timed out waiting for publishDiagnostics on {uri}")
+    finally:
+        client._diag_events.pop(uri, None)  # type: ignore[attr-defined]
 
-    pytest.fail(f"Timed out waiting for publishDiagnostics on {uri}")
-    return []  # unreachable, but satisfies type checker
+    return client._published.get(uri, [])  # type: ignore[attr-defined]
 
 
 # --------------------------------------------------------------------------
@@ -2077,7 +2086,7 @@ class TestCacheClear:
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.timeout(30)
+@pytest.mark.timeout(60)
 class TestLspLifecycle:
     """Full LSP lifecycle tests via real stdio transport — zero mocks."""
 


### PR DESCRIPTION
## Summary

- Add `lspServers` to `.claude-plugin/plugin.json` so Claude Code auto-starts `java-functional-lsp` for `.java` files when the plugin is installed (no manual `settings.json` edit needed)
- Add `startupTimeout` (120s for jdtls cold start), `restartOnCrash`, and `maxRestarts` to both `plugin.json` and the README/SKILL.md manual setup examples
- Bump plugin version `0.4.1` → `0.4.2`
- Fix flaky macOS CI: `@pytest.mark.timeout(30)` was too tight for fixture setup on slow runners; bumped to 60s. Also replaced busy-polling in `_open_and_wait_for_diagnostics` with `asyncio.wait_for(event.wait())` for a cleaner implementation. See #79.

## Why the CI failed

`@pytest.mark.timeout(30)` on `TestLspLifecycle` covers the **entire test including fixture setup**. The `lsp_client` fixture spawns a Python subprocess and does an LSP `initialize` handshake — on a loaded macOS runner this can exceed 30s. Previous runs on `main` were fast enough; this run hit a slow runner. Fixed by bumping the timeout to 60s.

## Test plan

- [ ] All CI checks green (Test matrix × 4 Python versions × 2 OS + CodeQL)
- [ ] `claude plugin install` on a fresh repo auto-starts the LSP server without any `settings.json` edit