### PR TITLE
fix(tests): address review findings from #78 + update doc ENABLE_LSP_TOOL references

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,17 @@ See [editors/intellij/README.md](editors/intellij/README.md) for detailed instru
 
 **Step 1: Enable LSP support** (required, one-time):
 
-Add to `~/.claude/settings.json`:
+Add `lspServers` to `~/.claude/settings.json` (the plugin handles this automatically — only needed for manual setup):
 ```json
 {
-  "env": {
-    "ENABLE_LSP_TOOL": "1"
+  "lspServers": {
+    "java-functional": {
+      "command": "java-functional-lsp",
+      "extensionToLanguage": { ".java": "java" },
+      "startupTimeout": 120000,
+      "restartOnCrash": true,
+      "maxRestarts": 5
+    }
   }
 }
 ```
@@ -178,7 +184,7 @@ moving on. Fix any type errors or missing imports immediately.
 
 | Issue | Fix |
 |-------|-----|
-| No diagnostics appear | Ensure `ENABLE_LSP_TOOL=1` is set, restart Claude Code |
+| No diagnostics appear | Ensure `lspServers` is configured (plugin or settings.json), restart |
 | "java-functional-lsp not found" | Run `brew install aviadshiber/tap/java-functional-lsp` |
 | Plugin not active | Run `claude plugin list` to verify, then `/reload-plugins` |
 | Diagnostics slow on first open | Normal — tree-sitter parses on first load, then incremental |

--- a/SKILL.md
+++ b/SKILL.md
@@ -112,10 +112,7 @@ To release a new version:
 
 ## Enabling LSP in Claude Code
 
-LSP support requires `ENABLE_LSP_TOOL=1` in `~/.claude/settings.json`:
-```json
-{ "env": { "ENABLE_LSP_TOOL": "1" } }
-```
+Declare `lspServers` in `~/.claude/settings.json` or in `plugin.json` — Claude Code enables the LSP tool automatically when `lspServers` is configured. `ENABLE_LSP_TOOL=1` is no longer needed.
 
 For containers or CI, add a `.lsp.json` at the project root instead of installing the plugin:
 ```json
@@ -130,7 +127,7 @@ Fix any violations immediately — do not explain, just apply the fix.
 
 ## Troubleshooting
 
-- **No diagnostics in Claude Code**: Ensure `ENABLE_LSP_TOOL=1` is set, restart Claude Code
+- **No diagnostics in Claude Code**: Ensure `lspServers` is configured (in `plugin.json` or `settings.json`), restart Claude Code
 - **"java-functional-lsp not found"**: Run `brew install aviadshiber/tap/java-functional-lsp`
 - **No completions/hover**: Install jdtls: `brew install jdtls` (requires JDK 21+)
 - **Too many warnings**: Create `.java-functional-lsp.json` with `excludes` or per-rule severity

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -130,8 +130,15 @@ async def _open_and_wait_for_diagnostics(
     an asyncio.Event that on_publish signals, then await it with wait_for so the
     full timeout is always respected — even when the event loop is transiently
     busy (e.g. jdtls subprocess creation on a slow macOS runner).
+
+    Note: the server always emits publishDiagnostics for every opened file
+    (including clean ones with zero findings) synchronously inside on_did_open,
+    before jdtls is involved. The event is therefore guaranteed to fire on the
+    first — and correct — notification for each URI in this test setup.
     """
     client._published.pop(uri, None)  # type: ignore[attr-defined]
+    # Register event before sending didOpen — no await between these two lines,
+    # so on_publish cannot fire and miss the registration.
     event = asyncio.Event()
     client._diag_events[uri] = event  # type: ignore[attr-defined]
 
@@ -149,11 +156,15 @@ async def _open_and_wait_for_diagnostics(
     try:
         await asyncio.wait_for(event.wait(), timeout=timeout)
     except asyncio.TimeoutError:
+        # pytest.fail() raises Failed (a BaseException subclass);
+        # the finally block below still runs before the exception propagates.
         pytest.fail(f"Timed out waiting for publishDiagnostics on {uri}")
     finally:
         client._diag_events.pop(uri, None)  # type: ignore[attr-defined]
 
-    return client._published.get(uri, [])  # type: ignore[attr-defined]
+    # on_publish stores to _published before setting the event, so the key
+    # is guaranteed to exist here — use direct access to surface any violation.
+    return client._published[uri]  # type: ignore[attr-defined]
 
 
 # --------------------------------------------------------------------------
@@ -2086,7 +2097,7 @@ class TestCacheClear:
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(60)  # covers fixture setup (subprocess spawn + initialize handshake) on slow macOS runners
 class TestLspLifecycle:
     """Full LSP lifecycle tests via real stdio transport — zero mocks."""
 


### PR DESCRIPTION
## Summary

Follow-up to #78 based on review ensemble findings.

**`tests/test_server.py`:**
- Return `client._published[uri]` directly instead of `.get(uri, [])` — `on_publish` stores to `_published` before setting the event, so the key is guaranteed present; direct access surfaces any violation instead of silently returning `[]`
- Add comments clarifying: no-await invariant between `pop` and event registration, `pytest.fail()` exception semantics in `finally`, and why the event fires on the correct (first) notification per URI
- Add inline comment to `@pytest.mark.timeout(60)` explaining it covers fixture setup (subprocess spawn + initialize handshake) on slow macOS runners

**`README.md` / `SKILL.md`:**
- Replace `ENABLE_LSP_TOOL=1` references with `lspServers` config (the correct mechanism since Claude Code added `lspServers` support)
- Update troubleshooting entries to reference `lspServers` instead of the env var

## Test plan

- [ ] All CI checks green