### PR TITLE
fix(cli): handle --help/-h after 'check' subcommand

### DIFF
--- a/editors/intellij/README.md
+++ b/editors/intellij/README.md
@@ -84,7 +84,7 @@ The server automatically detects JetBrains IDEs and disables the jdtls proxy —
 ### No diagnostics appear
 - Ensure the file mapping is set to Language: `Java`, Language ID: `java`
 - Check that `.java-functional-lsp.json` doesn't have rules set to `"off"`
-- Try restarting the language server: **Tools** → **Language Servers** → **Restart**
+- Try restarting the language server: **Language Servers** (search it in intellij Actions [Double Shift on keyboard]) → click on java-functional-lsp → **Restart**
 - If diagnostics worked before but stopped, the jdtls proxy may be interfering. Set `JAVA_FUNCTIONAL_LSP_JDTLS=off` in the server command environment to force-disable jdtls. The server auto-detects JetBrains IDEs and disables jdtls by default (since IntelliJ provides native Java support), but this can be overridden with `JAVA_FUNCTIONAL_LSP_JDTLS=on`.
 
 ### PATH not found

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.9.15"
+version = "0.9.16"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.9.14"
+__version__ = "0.9.16"

--- a/src/java_functional_lsp/cli.py
+++ b/src/java_functional_lsp/cli.py
@@ -66,14 +66,41 @@ def format_diagnostic(path: Path, d: Diagnostic) -> str:
     return f"{path}:{d.line + 1}:{d.col}: [{sym}] {d.code}: {d.message}"
 
 
+_USAGE = """\
+Usage: java-functional-lsp check <file.java> [file2.java ...]
+       java-functional-lsp check --dir <directory>
+       java-functional-lsp          (start LSP server on stdio)"""
+
+
+def _collect_files(args: list[str]) -> list[Path]:
+    """Resolve CLI args to a list of .java paths."""
+    files: list[Path] = []
+    if args and args[0] == "--dir":
+        if len(args) < 2:
+            print("Error: --dir requires a directory path", file=sys.stderr)
+            sys.exit(1)
+        directory = Path(args[1])
+        if not directory.is_dir():
+            print(f"Error: {directory} is not a directory", file=sys.stderr)
+            sys.exit(1)
+        return sorted(directory.rglob("*.java"))
+    for arg in args:
+        p = Path(arg)
+        if p.is_file():
+            files.append(p)
+        elif p.is_dir():
+            files.extend(sorted(p.rglob("*.java")))
+        else:
+            print(f"Warning: {arg} not found, skipping", file=sys.stderr)
+    return files
+
+
 def main() -> None:
     """CLI entry point: java-functional-lsp check <files...>"""
     args = sys.argv[1:]
 
     if args and args[0] in ("-h", "--help"):
-        print("Usage: java-functional-lsp check <file.java> [file2.java ...]")
-        print("       java-functional-lsp check --dir <directory>")
-        print("       java-functional-lsp          (start LSP server on stdio)")
+        print(_USAGE)
         sys.exit(0)
 
     if not args or args[0] != "check":
@@ -85,34 +112,16 @@ def main() -> None:
 
     args = args[1:]  # skip "check"
 
-    # Collect files
-    files: list[Path] = []
-    if args and args[0] == "--dir":
-        if len(args) < 2:
-            print("Error: --dir requires a directory path", file=sys.stderr)
-            sys.exit(1)
-        directory = Path(args[1])
-        if not directory.is_dir():
-            print(f"Error: {directory} is not a directory", file=sys.stderr)
-            sys.exit(1)
-        files = sorted(directory.rglob("*.java"))
-    else:
-        for arg in args:
-            p = Path(arg)
-            if p.is_file():
-                files.append(p)
-            elif p.is_dir():
-                files.extend(sorted(p.rglob("*.java")))
-            else:
-                print(f"Warning: {arg} not found, skipping", file=sys.stderr)
+    if args and args[0] in ("-h", "--help"):
+        print(_USAGE)
+        sys.exit(0)
 
+    files = _collect_files(args)
     if not files:
         print("No .java files found", file=sys.stderr)
         sys.exit(1)
 
-    # Load config from first file's directory
     config = load_config(files[0])
-
     total_diags = 0
     excludes: list[str] = config.get("excludes", [])
     for path in files:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
-from java_functional_lsp.cli import check_file, format_diagnostic, load_config
+import pytest
+
+from java_functional_lsp.cli import check_file, format_diagnostic, load_config, main
 
 
 class TestCheckFile:
@@ -53,3 +56,26 @@ class TestLoadConfig:
     def test_missing_config(self, tmp_path: Path) -> None:
         config = load_config(tmp_path / "Test.java")
         assert config == {}
+
+
+class TestHelp:
+    def test_top_level_help(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("sys.argv", ["java-functional-lsp", "--help"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0
+        assert "check" in capsys.readouterr().out
+
+    def test_check_subcommand_help(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("sys.argv", ["java-functional-lsp", "check", "--help"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0
+        assert "check" in capsys.readouterr().out
+
+    def test_check_short_help(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("sys.argv", ["java-functional-lsp", "check", "-h"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0
+        assert "check" in capsys.readouterr().out

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -109,12 +109,17 @@ async def lsp_client(tmp_path: Any) -> LanguageClient:  # type: ignore[misc]
     try:
         yield client
     finally:
+        # Teardown with timeouts: the server subprocess may be mid-jdtls-startup
+        # on a slow CI runner, causing shutdown_async or stop to hang indefinitely.
         try:
-            await client.shutdown_async(None)
+            await asyncio.wait_for(client.shutdown_async(None), timeout=5.0)
             client.exit(None)
         except Exception:
             pass
-        await client.stop()
+        try:
+            await asyncio.wait_for(client.stop(), timeout=5.0)
+        except Exception:
+            pass
 
 
 async def _open_and_wait_for_diagnostics(


### PR DESCRIPTION
## Problem

`java-functional-lsp check --help` was treating `--help` as a file path:
```
Warning: --help not found, skipping
No .java files found
```

## Changes

**CLI fix (`cli.py`):**
- Add `--help`/`-h` check after stripping the `check` token
- Extract `_USAGE` constant and `_collect_files()` helper (also resolves `PLR0915` too-many-statements lint error)
- All three forms now work: `java-functional-lsp --help`, `check --help`, `check -h`

**Tests:** Added `TestHelp` covering all three invocations.

**IntelliJ README:** Clarify how to find the Language Servers restart action (use Double Shift → search "Language Servers").

**Version:** 0.9.15 → 0.9.16