### PR TITLE
feat: add --version / -v flag to CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.9.16"
+version = "0.9.17"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.9.16"
+__version__ = "0.9.17"

--- a/src/java_functional_lsp/cli.py
+++ b/src/java_functional_lsp/cli.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from . import __version__
 from .analyzers.base import Analyzer, Diagnostic, Severity, get_parser, is_excluded
 from .analyzers.exception_checker import ExceptionChecker
 from .analyzers.functional_checker import FunctionalChecker
@@ -69,7 +70,8 @@ def format_diagnostic(path: Path, d: Diagnostic) -> str:
 _USAGE = """\
 Usage: java-functional-lsp check <file.java> [file2.java ...]
        java-functional-lsp check --dir <directory>
-       java-functional-lsp          (start LSP server on stdio)"""
+       java-functional-lsp          (start LSP server on stdio)
+       java-functional-lsp --version"""
 
 
 def _collect_files(args: list[str]) -> list[Path]:
@@ -101,6 +103,10 @@ def main() -> None:
 
     if args and args[0] in ("-h", "--help"):
         print(_USAGE)
+        sys.exit(0)
+
+    if args and args[0] in ("-v", "--version"):
+        print(f"java-functional-lsp {__version__}")
         sys.exit(0)
 
     if not args or args[0] != "check":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,3 +79,19 @@ class TestHelp:
                 main()
         assert exc.value.code == 0
         assert "check" in capsys.readouterr().out
+
+
+class TestVersion:
+    def test_version_flag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("sys.argv", ["java-functional-lsp", "--version"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0
+        assert "java-functional-lsp" in capsys.readouterr().out
+
+    def test_version_short_flag(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("sys.argv", ["java-functional-lsp", "-v"]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+        assert exc.value.code == 0
+        assert "java-functional-lsp" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Adds `--version` / `-v` flag: prints `java-functional-lsp <version>` and exits 0
- Updates `--help` usage string to document the new flag
- Bumps version to 0.9.17

## Test plan
- [ ] `java-functional-lsp --version` prints version and exits 0
- [ ] `java-functional-lsp -v` same
- [ ] 2 new unit tests in `TestVersion` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)