### PR TITLE
fix: add _EternalStdinBuffer to prevent pygls shutdown on stdin EOF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.9.17"
+version = "0.9.18"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.9.17"
+__version__ = "0.9.18"

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -16,7 +16,11 @@ import time
 from collections import OrderedDict
 from collections.abc import Coroutine
 from pathlib import Path
-from typing import Any
+from threading import Event
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from typing import BinaryIO
 
 from lsprotocol import types as lsp
 from lsprotocol.converters import get_converter
@@ -1204,10 +1208,46 @@ def on_code_action(params: lsp.CodeActionParams) -> list[lsp.CodeAction] | None:
 # --- Entry point ---
 
 
+class _EternalStdinBuffer:
+    """Wraps sys.stdin.buffer so EOF never propagates to the pygls reader.
+
+    Claude Code (ENABLE_LSP_TOOL, versions ≤ 0.2.x) closes the LSP subprocess's
+    stdin pipe immediately after process startup — before sending any LSP messages.
+    pygls sees EOF on the first readline() and shuts down the server.
+
+    This wrapper intercepts that EOF: instead of returning b'' (which pygls's
+    run_async() treats as a signal to break its read loop and shut down), it
+    blocks the calling thread indefinitely via threading.Event.wait().
+
+    pygls uses a ThreadPoolExecutor for stdin reads (run_in_executor), so
+    blocking one thread does not stall the asyncio event loop — all other
+    coroutines (jdtls proxy, diagnostics publishing, etc.) remain responsive.
+
+    When Claude Code is fixed upstream, this class becomes a transparent pass-
+    through: data before EOF is forwarded unchanged; only the EOF itself is swallowed.
+    """
+
+    def __init__(self, buf: BinaryIO) -> None:
+        self._buf = buf
+        self._eof_gate = Event()  # never set — waits block forever
+
+    def readline(self) -> bytes:
+        line = self._buf.readline()
+        if not line:
+            self._eof_gate.wait()  # block forever instead of returning b''
+        return line
+
+    def read(self, n: int) -> bytes:
+        data = self._buf.read(n)
+        if not data:
+            self._eof_gate.wait()
+        return data
+
+
 def main() -> None:
     """Entry point for the LSP server."""
     logging.basicConfig(level=logging.INFO, format="%(name)s %(levelname)s: %(message)s")
-    server.start_io()
+    server.start_io(stdin=_EternalStdinBuffer(sys.stdin.buffer))  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.9.14"
+version = "0.9.18"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary

- Claude Code (`ENABLE_LSP_TOOL`, ≤ 0.2.x) closes the LSP subprocess's stdin pipe immediately after startup — before sending any LSP messages
- `pygls`'s `run_async()` calls `readline()` via `run_in_executor`; an empty return breaks the loop and shuts the server before the LSP handshake
- Add `_EternalStdinBuffer` that wraps `sys.stdin.buffer` — blocks on `threading.Event.wait()` instead of returning `b''` on EOF
- Since pygls uses `ThreadPoolExecutor` for stdin reads, blocking one thread never stalls the asyncio event loop
- When Claude Code is fixed upstream, the wrapper is a no-op: data flows through unchanged, only the EOF signal is swallowed

## Companion fix

Shell-level belt-and-suspenders in `deeperdive-marketplace/plugins/deeperdive-java-linter/scripts/start-lsp.sh`: routes stdin through a FIFO with a permanent write-end keeper (`tail -f /dev/null`), protecting the window between process spawn and the first `readline()`.

## Upstream issue

anthropics/claude-code#53837

## Test plan

- [ ] Start server with `java-functional-lsp </dev/null &` — server should **not** exit immediately (blocked in `_EternalStdinBuffer.readline()`)
- [ ] Send a valid `initialize` request via LSP framing — server responds normally
- [ ] Pyright: `uv run pyright` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)