### PR TITLE
fix: per-feature capability negotiation (Closes #85)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.9.18"
+version = "0.10.0"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.9.18"
+__version__ = "0.10.0"

--- a/src/java_functional_lsp/capabilities/__init__.py
+++ b/src/java_functional_lsp/capabilities/__init__.py
@@ -1,0 +1,21 @@
+"""Capability negotiation — splits jdtls features into static-advertised vs
+dynamically-registered based on what the LSP client claims to support."""
+
+from __future__ import annotations
+
+from .handler_wiring import HandlerWiring
+from .negotiator import CapabilityNegotiator, NegotiationResult
+from .probe import ClientCapabilityProbe
+from .registry import REGISTRY, CapabilityEntry, all_methods
+from .static_builder import StaticCapabilityBuilder
+
+__all__ = [
+    "REGISTRY",
+    "CapabilityEntry",
+    "CapabilityNegotiator",
+    "ClientCapabilityProbe",
+    "HandlerWiring",
+    "NegotiationResult",
+    "StaticCapabilityBuilder",
+    "all_methods",
+]

--- a/src/java_functional_lsp/capabilities/handler_wiring.py
+++ b/src/java_functional_lsp/capabilities/handler_wiring.py
@@ -1,0 +1,69 @@
+"""Wire jdtls passthrough handlers into pygls' feature dispatcher.
+
+When `server.feature(method)(handler)` is called, pygls registers the handler so
+incoming requests for that method reach our code. The same call also influences
+pygls' auto-advertised capabilities, but we're not relying on that — we own the
+ServerCapabilities object explicitly via StaticCapabilityBuilder.
+
+`wire_eager` and `wire_lazy` share their body. Different names exist so the
+call-site intent (during `on_initialize` vs after jdtls warm-up) is self-evident.
+That readability is the SRP win.
+
+Idempotency: pygls' FeatureManager raises FeatureAlreadyRegisteredError if a
+method is registered twice. Tests use a module-level `server` singleton across
+many initialize cycles, so we skip already-registered methods rather than
+re-raising. In production the same guard is harmless — the second call is just
+a no-op.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from .registry import CapabilityEntry
+
+
+class HandlerWiring:
+    """Registers pygls feature handlers for capability entries."""
+
+    def __init__(self, server: Any, handlers: Mapping[str, Callable[..., Any]]) -> None:
+        self._server = server
+        self._handlers = handlers
+
+    def wire_eager(self, entries: Sequence[CapabilityEntry]) -> None:
+        """Wire handlers immediately (call from on_initialize for static features)."""
+        self._wire(entries)
+
+    def wire_lazy(self, entries: Sequence[CapabilityEntry]) -> None:
+        """Wire handlers after jdtls warm-up (call before client/registerCapability)."""
+        self._wire(entries)
+
+    def _wire(self, entries: Sequence[CapabilityEntry]) -> None:
+        for entry in entries:
+            for method in self._methods_for(entry):
+                handler = self._handlers.get(method)
+                if handler is None:
+                    continue
+                if self._already_registered(method):
+                    continue
+                self._server.feature(method)(handler)
+
+    def _already_registered(self, method: str) -> bool:
+        """Check whether pygls already has a handler bound for `method`.
+
+        We probe `server.protocol.fm._features` (pygls FeatureManager). If the
+        attribute path isn't there (custom server stand-ins in tests), assume
+        not-registered and let the caller proceed.
+        """
+        protocol = getattr(self._server, "protocol", None)
+        fm = getattr(protocol, "fm", None) if protocol is not None else None
+        features = getattr(fm, "_features", None) if fm is not None else None
+        if features is None:
+            return False
+        return method in features
+
+    @staticmethod
+    def _methods_for(entry: CapabilityEntry) -> tuple[str, ...]:
+        """Return parent method + any sub-methods that ride along with it."""
+        return (entry.lsp_method, *entry.sub_methods)

--- a/src/java_functional_lsp/capabilities/negotiator.py
+++ b/src/java_functional_lsp/capabilities/negotiator.py
@@ -1,0 +1,53 @@
+"""Decide which capabilities to advertise statically vs dynamically.
+
+Given the registry and a probe, split entries into two groups:
+- dynamic: client advertised dynamicRegistration support → register via
+  client/registerCapability after jdtls warms up. Preserves PR #44 behavior
+  (don't claim hover before jdtls is ready, so the IDE keeps showing its
+  own diagnostic tooltips).
+- static: client did not → advertise in the InitializeResult so clients that
+  ignore client/registerCapability (like Claude Code) still route correctly.
+
+This module is pure logic — no I/O, no mutation of pygls state. That keeps it
+trivially unit-testable with hand-built probes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .probe import ClientCapabilityProbe
+from .registry import REGISTRY, CapabilityEntry
+
+
+@dataclass(frozen=True)
+class NegotiationResult:
+    """Output of CapabilityNegotiator.negotiate.
+
+    static: entries to advertise in InitializeResult.ServerCapabilities.
+    dynamic: entries to register later via client/registerCapability.
+    """
+
+    static: tuple[CapabilityEntry, ...]
+    dynamic: tuple[CapabilityEntry, ...]
+
+
+class CapabilityNegotiator:
+    """Splits a capability registry into static/dynamic subsets per client probe."""
+
+    def __init__(
+        self,
+        probe: ClientCapabilityProbe,
+        registry: Sequence[CapabilityEntry] = REGISTRY,
+    ) -> None:
+        self._registry = tuple(registry)
+        self._probe = probe
+
+    def negotiate(self) -> NegotiationResult:
+        static: list[CapabilityEntry] = []
+        dynamic: list[CapabilityEntry] = []
+        for entry in self._registry:
+            target = dynamic if self._probe.supports_dynamic(entry.client_cap_path) else static
+            target.append(entry)
+        return NegotiationResult(static=tuple(static), dynamic=tuple(dynamic))

--- a/src/java_functional_lsp/capabilities/probe.py
+++ b/src/java_functional_lsp/capabilities/probe.py
@@ -15,6 +15,7 @@ client does not advertise support.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from functools import cache
 from typing import Any
 
 import lsprotocol.types as lsp
@@ -64,7 +65,13 @@ def _read_dynamic_registration(node: Any) -> bool:
     return bool(getattr(node, "dynamic_registration", None))
 
 
+@cache
 def _snake_to_camel(key: str) -> str:
-    """`text_document` -> `textDocument`. Idempotent for already-camel names."""
+    """`text_document` -> `textDocument`. Idempotent for already-camel names.
+
+    Cached because the LSP key space is bounded (~20 field names) but this is
+    called per-segment, per-entry, per-initialize when a client sends raw-dict
+    capabilities — repeated string allocation otherwise.
+    """
     head, *tail = key.split("_")
     return head + "".join(part.capitalize() for part in tail)

--- a/src/java_functional_lsp/capabilities/probe.py
+++ b/src/java_functional_lsp/capabilities/probe.py
@@ -1,0 +1,70 @@
+"""Read-only inspection of the client's declared capabilities.
+
+Pygls hands `on_initialize` a `lsp.InitializeParams` whose `capabilities` field is
+an attrs-based `ClientCapabilities` object. We walk a path like
+`("text_document", "hover")` and return whether the client opted in to LSP
+`dynamicRegistration` for that feature.
+
+We intentionally accept both attrs-dataclass shapes and dicts at every level
+because some clients send vendor-specific extensions as raw dicts that pygls
+leaves untouched. Returning `False` (rather than raising) on missing nodes
+matches the LSP spec's default: absence of `dynamicRegistration` means the
+client does not advertise support.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import lsprotocol.types as lsp
+
+
+class ClientCapabilityProbe:
+    """Wraps `params.capabilities` and answers per-feature support questions."""
+
+    def __init__(self, params: lsp.InitializeParams) -> None:
+        self._caps: Any = params.capabilities
+
+    def supports_dynamic(self, path: tuple[str, ...]) -> bool:
+        """Return True if the client claims dynamicRegistration support for `path`.
+
+        `path` walks into ClientCapabilities — e.g., ("text_document", "hover")
+        means `params.capabilities.text_document.hover.dynamic_registration`.
+        Empty path or a missing intermediate node yields False (no support).
+        """
+        if not path:
+            return False
+        node: Any = self._caps
+        for key in path:
+            node = _walk(node, key)
+            if node is None:
+                return False
+        return _read_dynamic_registration(node)
+
+
+def _walk(node: Any, key: str) -> Any:
+    """Get a child of `node` by `key`, supporting both attrs/dataclass and dict shapes."""
+    if node is None:
+        return None
+    if isinstance(node, Mapping):
+        # Try snake_case first, then the camelCase the wire protocol uses.
+        if key in node:
+            return node[key]
+        return node.get(_snake_to_camel(key))
+    return getattr(node, key, None)
+
+
+def _read_dynamic_registration(node: Any) -> bool:
+    """Return whether `node.dynamicRegistration` is truthy."""
+    if node is None:
+        return False
+    if isinstance(node, Mapping):
+        return bool(node.get("dynamic_registration") or node.get("dynamicRegistration"))
+    return bool(getattr(node, "dynamic_registration", None))
+
+
+def _snake_to_camel(key: str) -> str:
+    """`text_document` -> `textDocument`. Idempotent for already-camel names."""
+    head, *tail = key.split("_")
+    return head + "".join(part.capitalize() for part in tail)

--- a/src/java_functional_lsp/capabilities/registry.py
+++ b/src/java_functional_lsp/capabilities/registry.py
@@ -1,0 +1,188 @@
+"""Capability registry — single source of truth for jdtls-dependent LSP features.
+
+Each entry pairs an LSP method with everything needed to advertise it both ways:
+- statically in the InitializeResult.ServerCapabilities (for clients that
+  ignore client/registerCapability, e.g., Claude Code)
+- dynamically via client/registerCapability after jdtls warms up (for clients
+  that respect dynamic registration, e.g., VS Code, IntelliJ-LSP4IJ — preserves
+  PR #44 behavior of not suppressing IDE diagnostic tooltips).
+
+The registry is data only. Decision logic lives in negotiator.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import lsprotocol.types as lsp
+
+_JAVA_SELECTOR = [lsp.TextDocumentFilterLanguage(language="java")]
+
+
+@dataclass(frozen=True)
+class CapabilityEntry:
+    """Metadata for one jdtls-dependent LSP capability.
+
+    Attributes:
+        id_suffix: Used to build the unique Registration.id for dynamic registration.
+        lsp_method: The LSP method this capability gates (e.g., "textDocument/hover").
+        static_field: Name of the kwarg on lsp.ServerCapabilities for static advertisement.
+        client_cap_path: Path to the client capability that signals dynamic-registration
+            support (e.g., ("text_document", "hover")). Compared against
+            params.capabilities at initialize time.
+        registration_options_factory: Builds the RegistrationOptions object used in
+            client/registerCapability for the dynamic path.
+        static_value_factory: Builds the value to assign to ServerCapabilities[static_field].
+            Most are simply `True`; some are options objects (CompletionOptions etc.).
+        sub_methods: LSP methods that share this capability's advertisement but need
+            their own pygls handler (e.g., callHierarchy/incomingCalls). These are
+            wired alongside lsp_method whenever the entry is activated (static or dynamic).
+    """
+
+    id_suffix: str
+    lsp_method: str
+    static_field: str
+    client_cap_path: tuple[str, ...]
+    registration_options_factory: Callable[[], Any]
+    static_value_factory: Callable[[], Any]
+    sub_methods: tuple[str, ...] = field(default_factory=tuple)
+
+
+REGISTRY: tuple[CapabilityEntry, ...] = (
+    CapabilityEntry(
+        id_suffix="completion",
+        lsp_method=lsp.TEXT_DOCUMENT_COMPLETION,
+        static_field="completion_provider",
+        client_cap_path=("text_document", "completion"),
+        registration_options_factory=lambda: lsp.CompletionRegistrationOptions(
+            document_selector=_JAVA_SELECTOR, trigger_characters=["."]
+        ),
+        static_value_factory=lambda: lsp.CompletionOptions(trigger_characters=["."]),
+    ),
+    CapabilityEntry(
+        id_suffix="hover",
+        lsp_method=lsp.TEXT_DOCUMENT_HOVER,
+        static_field="hover_provider",
+        client_cap_path=("text_document", "hover"),
+        registration_options_factory=lambda: lsp.HoverRegistrationOptions(document_selector=_JAVA_SELECTOR),
+        static_value_factory=lambda: True,
+    ),
+    CapabilityEntry(
+        id_suffix="definition",
+        lsp_method=lsp.TEXT_DOCUMENT_DEFINITION,
+        static_field="definition_provider",
+        client_cap_path=("text_document", "definition"),
+        registration_options_factory=lambda: lsp.DefinitionRegistrationOptions(document_selector=_JAVA_SELECTOR),
+        static_value_factory=lambda: True,
+    ),
+    CapabilityEntry(
+        id_suffix="references",
+        lsp_method=lsp.TEXT_DOCUMENT_REFERENCES,
+        static_field="references_provider",
+        client_cap_path=("text_document", "references"),
+        registration_options_factory=lambda: lsp.ReferenceRegistrationOptions(document_selector=_JAVA_SELECTOR),
+        static_value_factory=lambda: True,
+    ),
+    CapabilityEntry(
+        id_suffix="document-symbol",
+        lsp_method=lsp.TEXT_DOCUMENT_DOCUMENT_SYMBOL,
+        static_field="document_symbol_provider",
+        client_cap_path=("text_document", "document_symbol"),
+        registration_options_factory=lambda: lsp.DocumentSymbolRegistrationOptions(document_selector=_JAVA_SELECTOR),
+        static_value_factory=lambda: True,
+    ),
+    CapabilityEntry(
+        id_suffix="call-hierarchy",
+        lsp_method=lsp.TEXT_DOCUMENT_PREPARE_CALL_HIERARCHY,
+        static_field="call_hierarchy_provider",
+        client_cap_path=("text_document", "call_hierarchy"),
+        registration_options_factory=lambda: lsp.CallHierarchyRegistrationOptions(document_selector=_JAVA_SELECTOR),
+        static_value_factory=lambda: True,
+        sub_methods=(lsp.CALL_HIERARCHY_INCOMING_CALLS, lsp.CALL_HIERARCHY_OUTGOING_CALLS),
+    ),
+    CapabilityEntry(
+        id_suffix="signature-help",
+        lsp_method=lsp.TEXT_DOCUMENT_SIGNATURE_HELP,
+        static_field="signature_help_provider",
+        client_cap_path=("text_document", "signature_help"),
+        registration_options_factory=lambda: lsp.SignatureHelpRegistrationOptions(
+            document_selector=_JAVA_SELECTOR,
+            trigger_characters=["(", ","],
+            retrigger_characters=[")"],
+        ),
+        static_value_factory=lambda: lsp.SignatureHelpOptions(
+            trigger_characters=["(", ","], retrigger_characters=[")"]
+        ),
+    ),
+    CapabilityEntry(
+        id_suffix="implementation",
+        lsp_method=lsp.TEXT_DOCUMENT_IMPLEMENTATION,
+        static_field="implementation_provider",
+        client_cap_path=("text_document", "implementation"),
+        registration_options_factory=lambda: lsp.ImplementationRegistrationOptions(document_selector=_JAVA_SELECTOR),
+        static_value_factory=lambda: True,
+    ),
+    CapabilityEntry(
+        id_suffix="type-definition",
+        lsp_method=lsp.TEXT_DOCUMENT_TYPE_DEFINITION,
+        static_field="type_definition_provider",
+        client_cap_path=("text_document", "type_definition"),
+        registration_options_factory=lambda: lsp.TypeDefinitionRegistrationOptions(document_selector=_JAVA_SELECTOR),
+        static_value_factory=lambda: True,
+    ),
+    CapabilityEntry(
+        id_suffix="declaration",
+        lsp_method=lsp.TEXT_DOCUMENT_DECLARATION,
+        static_field="declaration_provider",
+        client_cap_path=("text_document", "declaration"),
+        registration_options_factory=lambda: lsp.DeclarationRegistrationOptions(document_selector=_JAVA_SELECTOR),
+        static_value_factory=lambda: True,
+    ),
+    CapabilityEntry(
+        id_suffix="document-highlight",
+        lsp_method=lsp.TEXT_DOCUMENT_DOCUMENT_HIGHLIGHT,
+        static_field="document_highlight_provider",
+        client_cap_path=("text_document", "document_highlight"),
+        registration_options_factory=lambda: lsp.DocumentHighlightRegistrationOptions(document_selector=_JAVA_SELECTOR),
+        static_value_factory=lambda: True,
+    ),
+    CapabilityEntry(
+        id_suffix="rename",
+        lsp_method=lsp.TEXT_DOCUMENT_RENAME,
+        static_field="rename_provider",
+        client_cap_path=("text_document", "rename"),
+        registration_options_factory=lambda: lsp.RenameRegistrationOptions(
+            document_selector=_JAVA_SELECTOR, prepare_provider=True
+        ),
+        static_value_factory=lambda: lsp.RenameOptions(prepare_provider=True),
+        sub_methods=(lsp.TEXT_DOCUMENT_PREPARE_RENAME,),
+    ),
+    CapabilityEntry(
+        id_suffix="type-hierarchy",
+        lsp_method=lsp.TEXT_DOCUMENT_PREPARE_TYPE_HIERARCHY,
+        static_field="type_hierarchy_provider",
+        client_cap_path=("text_document", "type_hierarchy"),
+        registration_options_factory=lambda: lsp.TypeHierarchyRegistrationOptions(document_selector=_JAVA_SELECTOR),
+        static_value_factory=lambda: True,
+        sub_methods=(lsp.TYPE_HIERARCHY_SUPERTYPES, lsp.TYPE_HIERARCHY_SUBTYPES),
+    ),
+    CapabilityEntry(
+        id_suffix="workspace-symbol",
+        lsp_method=lsp.WORKSPACE_SYMBOL,
+        static_field="workspace_symbol_provider",
+        client_cap_path=("workspace", "symbol"),
+        registration_options_factory=lsp.WorkspaceSymbolRegistrationOptions,
+        static_value_factory=lambda: True,
+    ),
+)
+
+
+def all_methods(entries: tuple[CapabilityEntry, ...] = REGISTRY) -> tuple[str, ...]:
+    """Return every LSP method (parent + sub) reachable from `entries`."""
+    methods: list[str] = []
+    for entry in entries:
+        methods.append(entry.lsp_method)
+        methods.extend(entry.sub_methods)
+    return tuple(methods)

--- a/src/java_functional_lsp/capabilities/registry.py
+++ b/src/java_functional_lsp/capabilities/registry.py
@@ -173,7 +173,10 @@ REGISTRY: tuple[CapabilityEntry, ...] = (
         lsp_method=lsp.WORKSPACE_SYMBOL,
         static_field="workspace_symbol_provider",
         client_cap_path=("workspace", "symbol"),
-        registration_options_factory=lsp.WorkspaceSymbolRegistrationOptions,
+        # Lambda kept (vs bare class) for consistency with the other entries' Callable[[], Any]
+        # contract — defends against a silent semantic change if WorkspaceSymbolRegistrationOptions
+        # ever gains a required constructor arg.
+        registration_options_factory=lambda: lsp.WorkspaceSymbolRegistrationOptions(),  # noqa: PLW0108
         static_value_factory=lambda: True,
     ),
 )

--- a/src/java_functional_lsp/capabilities/static_builder.py
+++ b/src/java_functional_lsp/capabilities/static_builder.py
@@ -1,0 +1,41 @@
+"""Assemble the lsp.ServerCapabilities returned in InitializeResult.
+
+Single responsibility: take the static-advertised entries from the negotiator and
+build a `ServerCapabilities` object combining them with the always-static base
+(text_document_sync + code_action_provider for our QuickFix custom diagnostics).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import lsprotocol.types as lsp
+
+from .registry import CapabilityEntry
+
+_TEXT_DOC_SYNC = lsp.TextDocumentSyncOptions(
+    open_close=True,
+    change=lsp.TextDocumentSyncKind.Full,
+    save=lsp.SaveOptions(include_text=True),
+)
+
+_CODE_ACTION_OPTIONS = lsp.CodeActionOptions(code_action_kinds=[lsp.CodeActionKind.QuickFix])
+
+
+class StaticCapabilityBuilder:
+    """Builds the ServerCapabilities object for the InitializeResult.
+
+    The base capabilities (text_document_sync, code_action_provider) are always
+    advertised because they are fully owned by this server (custom diagnostics
+    + QuickFix code actions) — they don't depend on jdtls warm-up.
+    """
+
+    def build(self, static_entries: Sequence[CapabilityEntry]) -> lsp.ServerCapabilities:
+        kwargs: dict[str, Any] = {
+            "text_document_sync": _TEXT_DOC_SYNC,
+            "code_action_provider": _CODE_ACTION_OPTIONS,
+        }
+        for entry in static_entries:
+            kwargs[entry.static_field] = entry.static_value_factory()
+        return lsp.ServerCapabilities(**kwargs)

--- a/src/java_functional_lsp/server.py
+++ b/src/java_functional_lsp/server.py
@@ -34,6 +34,14 @@ from .analyzers.functional_checker import FunctionalChecker
 from .analyzers.mutation_checker import MutationChecker
 from .analyzers.null_checker import NullChecker
 from .analyzers.spring_checker import SpringChecker
+from .capabilities import (
+    REGISTRY,
+    CapabilityEntry,
+    CapabilityNegotiator,
+    ClientCapabilityProbe,
+    HandlerWiring,
+    StaticCapabilityBuilder,
+)
 from .fixes import get_fix, get_fix_registry_keys
 from .proxy import JdtlsProxy, _module_snapshot_path, _resolve_module_uri
 
@@ -109,6 +117,10 @@ class JavaFunctionalLspServer(LanguageServer):
         self._skip_jdtls: bool = False
         self._skip_jdtls_registration: bool = False
         self._init_generation: int = 0
+        # Capability entries the negotiator decided to register dynamically
+        # (client claimed dynamicRegistration support). Populated in
+        # on_initialize and consumed by _register_jdtls_capabilities.
+        self._dynamic_features: tuple[CapabilityEntry, ...] = ()
         # URIs the client has opened at least once this session (normalized form).
         # Jdtls indexes the whole workspace and publishes diagnostics for files the
         # client never touched; we only republish for URIs present here so unrelated
@@ -507,23 +519,21 @@ def on_initialize(params: lsp.InitializeParams) -> lsp.InitializeResult:
             client_name,
         )
 
-    return lsp.InitializeResult(
-        capabilities=lsp.ServerCapabilities(
-            text_document_sync=lsp.TextDocumentSyncOptions(
-                open_close=True,
-                change=lsp.TextDocumentSyncKind.Full,
-                save=lsp.SaveOptions(include_text=True),
-            ),
-            # Only advertise capabilities we own (custom diagnostics + code actions).
-            # jdtls-dependent features (hover, definition, references, completion,
-            # documentSymbol) are registered dynamically after jdtls starts — see
-            # on_initialized(). This prevents us from claiming hover when jdtls
-            # isn't ready, which would suppress the IDE's diagnostic tooltips.
-            code_action_provider=lsp.CodeActionOptions(
-                code_action_kinds=[lsp.CodeActionKind.QuickFix],
-            ),
-        )
-    )
+    # Per-feature capability negotiation. Clients that claim LSP dynamicRegistration
+    # support get the dynamic path (preserves PR #44 behavior — IDE keeps showing
+    # its own diagnostic tooltips while jdtls warms up). Clients that don't
+    # (notably Claude Code 2.1.x, which ignores client/registerCapability for
+    # routing) get static advertisement so their LSP routing picks up our handlers.
+    probe = ClientCapabilityProbe(params)
+    negotiation = CapabilityNegotiator(probe).negotiate()
+    server._dynamic_features = negotiation.dynamic
+
+    # Wire pygls handlers eagerly for static-advertised features so they dispatch
+    # immediately. Dynamic features have their handlers wired later in
+    # _register_jdtls_capabilities, after jdtls warm-up.
+    HandlerWiring(server, _JDTLS_HANDLERS).wire_eager(negotiation.static)
+
+    return lsp.InitializeResult(capabilities=StaticCapabilityBuilder().build(negotiation.static))
 
 
 @server.feature(lsp.INITIALIZED)
@@ -542,84 +552,61 @@ async def on_initialized(_: lsp.InitializedParams) -> None:
         logger.info("jdtls not on PATH — running with custom rules only")
 
 
-_JAVA_SELECTOR = [lsp.TextDocumentFilterLanguage(language="java")]
-
 _JDTLS_REG_PREFIX = "jdtls-"
 
-# jdtls-dependent capabilities registered dynamically after the proxy starts.
-# Each entry: (id_suffix, LSP method, registration options class, extra kwargs).
-_JDTLS_CAPABILITIES: list[tuple[str, str, type[Any], dict[str, Any]]] = [
-    ("completion", lsp.TEXT_DOCUMENT_COMPLETION, lsp.CompletionRegistrationOptions, {"trigger_characters": ["."]}),
-    ("hover", lsp.TEXT_DOCUMENT_HOVER, lsp.HoverRegistrationOptions, {}),
-    ("definition", lsp.TEXT_DOCUMENT_DEFINITION, lsp.DefinitionRegistrationOptions, {}),
-    ("references", lsp.TEXT_DOCUMENT_REFERENCES, lsp.ReferenceRegistrationOptions, {}),
-    ("document-symbol", lsp.TEXT_DOCUMENT_DOCUMENT_SYMBOL, lsp.DocumentSymbolRegistrationOptions, {}),
-    ("call-hierarchy", lsp.TEXT_DOCUMENT_PREPARE_CALL_HIERARCHY, lsp.CallHierarchyRegistrationOptions, {}),
-    (
-        "signature-help",
-        lsp.TEXT_DOCUMENT_SIGNATURE_HELP,
-        lsp.SignatureHelpRegistrationOptions,
-        {"trigger_characters": ["(", ","], "retrigger_characters": [")"]},
-    ),
-    ("implementation", lsp.TEXT_DOCUMENT_IMPLEMENTATION, lsp.ImplementationRegistrationOptions, {}),
-    ("type-definition", lsp.TEXT_DOCUMENT_TYPE_DEFINITION, lsp.TypeDefinitionRegistrationOptions, {}),
-    ("declaration", lsp.TEXT_DOCUMENT_DECLARATION, lsp.DeclarationRegistrationOptions, {}),
-    ("document-highlight", lsp.TEXT_DOCUMENT_DOCUMENT_HIGHLIGHT, lsp.DocumentHighlightRegistrationOptions, {}),
-    ("rename", lsp.TEXT_DOCUMENT_RENAME, lsp.RenameRegistrationOptions, {"prepare_provider": True}),
-    ("type-hierarchy", lsp.TEXT_DOCUMENT_PREPARE_TYPE_HIERARCHY, lsp.TypeHierarchyRegistrationOptions, {}),
-    ("workspace-symbol", lsp.WORKSPACE_SYMBOL, lsp.WorkspaceSymbolRegistrationOptions, {}),
-]
-
-# Maps LSP method → handler function for dynamic registration.
+# Maps LSP method → handler function. Populated below (see _JDTLS_HANDLERS.update
+# at the bottom of this file). Read by HandlerWiring during on_initialize (for
+# static-advertised features) and again by _register_jdtls_capabilities (for
+# dynamic features). The split is decided by CapabilityNegotiator.
 _JDTLS_HANDLERS: dict[str, Any] = {}
 
 # Set after first successful registration to prevent FeatureAlreadyRegisteredError.
 _jdtls_capabilities_registered = False
 
 
-def _build_jdtls_registrations() -> list[lsp.Registration]:
-    """Build LSP Registration objects for jdtls-dependent capabilities."""
+def _build_jdtls_registrations(entries: tuple[CapabilityEntry, ...] = REGISTRY) -> list[lsp.Registration]:
+    """Build LSP Registration objects for the given capability entries.
+
+    Used by _register_jdtls_capabilities to send client/registerCapability for
+    dynamic-path features. Each Registration carries the LSP method id, a unique
+    id (jdtls-<suffix>), and the unstructured registration options.
+    """
     result = []
-    for suffix, method, opts_cls, extra in _JDTLS_CAPABILITIES:
-        field_names = {f.name for f in getattr(opts_cls, "__attrs_attrs__", [])}
-        kwargs: dict[str, Any] = {**extra}
-        if "document_selector" in field_names:
-            kwargs["document_selector"] = _JAVA_SELECTOR
+    for entry in entries:
         result.append(
             lsp.Registration(
-                id=f"{_JDTLS_REG_PREFIX}{suffix}",
-                method=method,
-                register_options=_converter.unstructure(opts_cls(**kwargs)),
+                id=f"{_JDTLS_REG_PREFIX}{entry.id_suffix}",
+                method=entry.lsp_method,
+                register_options=_converter.unstructure(entry.registration_options_factory()),
             )
         )
     return result
 
 
 async def _register_jdtls_capabilities() -> None:
-    """Dynamically register jdtls-dependent capabilities after the proxy starts.
+    """Send client/registerCapability for the entries the negotiator marked dynamic.
 
-    We don't advertise these in the static InitializeResult because doing so
-    would make the IDE defer hover/definition/etc to us even before jdtls is
-    ready, which suppresses the IDE's built-in diagnostic tooltips.
+    Static-advertised features were already wired up during on_initialize. This
+    function only handles the dynamic subset — features whose clients claimed
+    LSP dynamicRegistration support, where deferring advertisement until jdtls
+    is warm preserves the IDE's own diagnostic tooltips (PR #44 invariant).
 
-    Idempotent: safe to call multiple times (e.g., proxy restart).
-    Uses a generation counter to detect stale registrations from a prior
-    initialize cycle (defensive against non-standard re-initialization).
+    Idempotent: safe to call multiple times. Uses a generation counter to
+    detect stale registrations from a prior initialize cycle.
     """
     global _jdtls_capabilities_registered
     if _jdtls_capabilities_registered:
         return
 
     generation = server._init_generation
+    entries = server._dynamic_features
 
     try:
-        # Register handlers so pygls dispatches incoming requests to them.
-        for method, handler in _JDTLS_HANDLERS.items():
-            server.feature(method)(handler)
+        HandlerWiring(server, _JDTLS_HANDLERS).wire_lazy(entries)
 
-        # Tell the client we now support these capabilities.
-        registrations = _build_jdtls_registrations()
-        await server.client_register_capability_async(lsp.RegistrationParams(registrations=registrations))
+        registrations = _build_jdtls_registrations(entries)
+        if registrations:
+            await server.client_register_capability_async(lsp.RegistrationParams(registrations=registrations))
 
         # Bail if a re-initialize happened while we were awaiting.
         if generation != server._init_generation:
@@ -627,11 +614,11 @@ async def _register_jdtls_capabilities() -> None:
             return
 
         _jdtls_capabilities_registered = True
-        logger.info(
-            "jdtls capabilities registered: completion, hover, definition, references, symbol, "
-            "call-hierarchy, signature-help, implementation, type-definition, declaration, "
-            "document-highlight, rename, type-hierarchy, workspace-symbol"
-        )
+        if entries:
+            suffixes = ", ".join(e.id_suffix for e in entries)
+            logger.info("jdtls capabilities registered dynamically: %s", suffixes)
+        else:
+            logger.info("No dynamic jdtls capabilities to register (all advertised statically)")
     except Exception:
         logger.warning("Failed to dynamically register jdtls capabilities", exc_info=True)
 

--- a/tests/test_capabilities/test_handler_wiring.py
+++ b/tests/test_capabilities/test_handler_wiring.py
@@ -1,0 +1,138 @@
+"""Tests for HandlerWiring.
+
+Asserts that `wire_eager` and `wire_lazy` register pygls feature handlers for
+each entry's parent method AND every sub-method (e.g., callHierarchy/incomingCalls
+rides along with the call_hierarchy parent capability).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import lsprotocol.types as lsp
+
+from java_functional_lsp.capabilities.handler_wiring import HandlerWiring
+from java_functional_lsp.capabilities.registry import REGISTRY, CapabilityEntry
+
+
+class _FakeServer:
+    """Minimal pygls stand-in that records `feature(method)(handler)` calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Callable[..., Any]]] = []
+
+    def feature(self, method: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        def decorator(handler: Callable[..., Any]) -> Callable[..., Any]:
+            self.calls.append((method, handler))
+            return handler
+
+        return decorator
+
+
+def _by_suffix(suffix: str) -> CapabilityEntry:
+    return next(e for e in REGISTRY if e.id_suffix == suffix)
+
+
+def _noop(*args: Any, **kwargs: Any) -> None:
+    _ = args, kwargs
+
+
+def _make_handlers(methods: list[str]) -> dict[str, Callable[..., Any]]:
+    return dict.fromkeys(methods, _noop)
+
+
+def test_wire_eager_registers_parent_method() -> None:
+    server = _FakeServer()
+    entry = _by_suffix("hover")
+    handlers = _make_handlers([entry.lsp_method])
+    HandlerWiring(server, handlers).wire_eager(entries=(entry,))
+    methods_registered = [call[0] for call in server.calls]
+    assert methods_registered == [lsp.TEXT_DOCUMENT_HOVER]
+
+
+def test_wire_eager_registers_sub_methods_with_parent() -> None:
+    """call-hierarchy entry should wire prepare + incoming + outgoing together."""
+    server = _FakeServer()
+    entry = _by_suffix("call-hierarchy")
+    handlers = _make_handlers([entry.lsp_method, *entry.sub_methods])
+    HandlerWiring(server, handlers).wire_eager(entries=(entry,))
+    methods_registered = {call[0] for call in server.calls}
+    assert methods_registered == {
+        lsp.TEXT_DOCUMENT_PREPARE_CALL_HIERARCHY,
+        lsp.CALL_HIERARCHY_INCOMING_CALLS,
+        lsp.CALL_HIERARCHY_OUTGOING_CALLS,
+    }
+
+
+def test_wire_lazy_uses_same_logic_as_eager() -> None:
+    server_e = _FakeServer()
+    server_l = _FakeServer()
+    entry = _by_suffix("rename")
+    handlers = _make_handlers([entry.lsp_method, *entry.sub_methods])
+    HandlerWiring(server_e, handlers).wire_eager(entries=(entry,))
+    HandlerWiring(server_l, handlers).wire_lazy(entries=(entry,))
+    assert {c[0] for c in server_e.calls} == {c[0] for c in server_l.calls}
+
+
+def test_missing_handler_is_silently_skipped() -> None:
+    """Robustness: an entry with no registered handler should not crash."""
+    server = _FakeServer()
+    entry = _by_suffix("hover")
+    HandlerWiring(server, handlers={}).wire_eager(entries=(entry,))
+    assert server.calls == []
+
+
+def test_partial_handlers_only_wires_present_ones() -> None:
+    """If parent has a handler but a sub-method does not, only the parent gets wired."""
+    server = _FakeServer()
+    entry = _by_suffix("call-hierarchy")
+    handlers = _make_handlers([entry.lsp_method])  # no sub-method handlers
+    HandlerWiring(server, handlers).wire_eager(entries=(entry,))
+    methods_registered = [call[0] for call in server.calls]
+    assert methods_registered == [lsp.TEXT_DOCUMENT_PREPARE_CALL_HIERARCHY]
+
+
+def test_wire_passes_actual_handler_function() -> None:
+    server = _FakeServer()
+    entry = _by_suffix("hover")
+
+    def sentinel(*args: Any, **kwargs: Any) -> str:
+        _ = args, kwargs
+        return "sentinel-result"
+
+    HandlerWiring(server, {entry.lsp_method: sentinel}).wire_eager(entries=(entry,))
+    assert server.calls[0][1] is sentinel
+
+
+class _PyglsLikeServer(_FakeServer):
+    """Stand-in that mimics pygls' `server.protocol.fm._features` registry."""
+
+    def __init__(self, prewired: list[str] | None = None) -> None:
+        super().__init__()
+        self.protocol = type("P", (), {"fm": type("F", (), {"_features": dict.fromkeys(prewired or [])})()})()
+
+    def feature(self, method: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        decorator = super().feature(method)
+
+        def wrapper(handler: Callable[..., Any]) -> Callable[..., Any]:
+            self.protocol.fm._features[method] = handler  # type: ignore[attr-defined]
+            return decorator(handler)
+
+        return wrapper
+
+
+def test_wire_skips_already_registered_methods() -> None:
+    """Idempotency guard: a method already in pygls' feature map is not re-registered."""
+    entry = _by_suffix("hover")
+    server = _PyglsLikeServer(prewired=[entry.lsp_method])
+    HandlerWiring(server, _make_handlers([entry.lsp_method])).wire_eager(entries=(entry,))
+    assert server.calls == []
+
+
+def test_wire_succeeds_when_pygls_state_is_absent() -> None:
+    """If `server.protocol.fm._features` isn't reachable, fall through to normal wiring."""
+    entry = _by_suffix("hover")
+    server = _FakeServer()  # plain fake — no protocol.fm
+    HandlerWiring(server, _make_handlers([entry.lsp_method])).wire_eager(entries=(entry,))
+    assert [c[0] for c in server.calls] == [entry.lsp_method]

--- a/tests/test_capabilities/test_negotiator.py
+++ b/tests/test_capabilities/test_negotiator.py
@@ -1,0 +1,78 @@
+"""Tests for CapabilityNegotiator.
+
+Pure decision logic — given a probe and a registry, the negotiator partitions
+entries into (static, dynamic). We construct fake probes (no real LSP) so
+the test asserts the pure function in isolation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from java_functional_lsp.capabilities.negotiator import CapabilityNegotiator, NegotiationResult
+from java_functional_lsp.capabilities.registry import REGISTRY, CapabilityEntry
+
+
+class _FakeProbe:
+    """Probe stub: returns True only for the paths we declare as 'dynamic-supported'."""
+
+    def __init__(self, dynamic_paths: Iterable[tuple[str, ...]]) -> None:
+        self._set = set(dynamic_paths)
+
+    def supports_dynamic(self, path: tuple[str, ...]) -> bool:
+        return path in self._set
+
+
+def _entries_for(suffixes: Iterable[str]) -> tuple[CapabilityEntry, ...]:
+    by_suffix = {e.id_suffix: e for e in REGISTRY}
+    return tuple(by_suffix[s] for s in suffixes)
+
+
+def test_all_static_when_probe_returns_false_everywhere() -> None:
+    probe = _FakeProbe(dynamic_paths=())
+    result = CapabilityNegotiator(probe).negotiate()
+    assert isinstance(result, NegotiationResult)
+    assert set(result.static) == set(REGISTRY)
+    assert result.dynamic == ()
+
+
+def test_all_dynamic_when_probe_returns_true_everywhere() -> None:
+    all_paths = [e.client_cap_path for e in REGISTRY]
+    probe = _FakeProbe(dynamic_paths=all_paths)
+    result = CapabilityNegotiator(probe).negotiate()
+    assert result.static == ()
+    assert set(result.dynamic) == set(REGISTRY)
+
+
+def test_partial_split() -> None:
+    """Hover supports dynamic; everything else is static — verifies per-feature split."""
+    hover_path = next(e.client_cap_path for e in REGISTRY if e.id_suffix == "hover")
+    probe = _FakeProbe(dynamic_paths=[hover_path])
+    result = CapabilityNegotiator(probe).negotiate()
+    dynamic_suffixes = {e.id_suffix for e in result.dynamic}
+    static_suffixes = {e.id_suffix for e in result.static}
+    assert dynamic_suffixes == {"hover"}
+    assert "hover" not in static_suffixes
+    assert len(static_suffixes) == len(REGISTRY) - 1
+
+
+def test_static_and_dynamic_are_disjoint() -> None:
+    probe = _FakeProbe(dynamic_paths=[("text_document", "hover"), ("workspace", "symbol")])
+    result = CapabilityNegotiator(probe).negotiate()
+    assert set(result.static).isdisjoint(set(result.dynamic))
+
+
+def test_custom_registry_is_respected() -> None:
+    """Passing an explicit (smaller) registry should only consider those entries."""
+    subset = _entries_for(["hover", "definition"])
+    probe = _FakeProbe(dynamic_paths=[("text_document", "hover")])
+    result = CapabilityNegotiator(probe, registry=subset).negotiate()
+    assert {e.id_suffix for e in result.dynamic} == {"hover"}
+    assert {e.id_suffix for e in result.static} == {"definition"}
+
+
+def test_result_uses_tuples_for_immutability() -> None:
+    probe = _FakeProbe(dynamic_paths=())
+    result = CapabilityNegotiator(probe).negotiate()
+    assert isinstance(result.static, tuple)
+    assert isinstance(result.dynamic, tuple)

--- a/tests/test_capabilities/test_probe.py
+++ b/tests/test_capabilities/test_probe.py
@@ -1,0 +1,108 @@
+"""Tests for ClientCapabilityProbe.
+
+The probe must read `dynamicRegistration` correctly from:
+- attrs-dataclass shapes (the normal pygls case),
+- dict shapes (vendor extensions, raw JSON not converted by pygls),
+- snake_case AND camelCase keys (depending on which side did the conversion).
+And it must never raise on missing nodes — absence implies "no support".
+"""
+
+from __future__ import annotations
+
+import lsprotocol.types as lsp
+
+from java_functional_lsp.capabilities.probe import ClientCapabilityProbe
+
+
+def _make_params(client_capabilities: lsp.ClientCapabilities) -> lsp.InitializeParams:
+    return lsp.InitializeParams(capabilities=client_capabilities)
+
+
+def test_dataclass_dynamic_registration_true() -> None:
+    caps = lsp.ClientCapabilities(
+        text_document=lsp.TextDocumentClientCapabilities(hover=lsp.HoverClientCapabilities(dynamic_registration=True))
+    )
+    probe = ClientCapabilityProbe(_make_params(caps))
+    assert probe.supports_dynamic(("text_document", "hover")) is True
+
+
+def test_dataclass_dynamic_registration_false() -> None:
+    caps = lsp.ClientCapabilities(
+        text_document=lsp.TextDocumentClientCapabilities(hover=lsp.HoverClientCapabilities(dynamic_registration=False))
+    )
+    probe = ClientCapabilityProbe(_make_params(caps))
+    assert probe.supports_dynamic(("text_document", "hover")) is False
+
+
+def test_dataclass_dynamic_registration_missing() -> None:
+    """When `dynamic_registration` field exists but is None, treat as no support."""
+    caps = lsp.ClientCapabilities(text_document=lsp.TextDocumentClientCapabilities(hover=lsp.HoverClientCapabilities()))
+    probe = ClientCapabilityProbe(_make_params(caps))
+    assert probe.supports_dynamic(("text_document", "hover")) is False
+
+
+def test_missing_intermediate_node_returns_false() -> None:
+    """If `text_document` is None or the feature itself is missing, return False."""
+    caps = lsp.ClientCapabilities(text_document=None)
+    probe = ClientCapabilityProbe(_make_params(caps))
+    assert probe.supports_dynamic(("text_document", "hover")) is False
+
+
+def test_feature_node_missing_returns_false() -> None:
+    caps = lsp.ClientCapabilities(text_document=lsp.TextDocumentClientCapabilities())
+    probe = ClientCapabilityProbe(_make_params(caps))
+    assert probe.supports_dynamic(("text_document", "hover")) is False
+
+
+def test_empty_path_returns_false() -> None:
+    caps = lsp.ClientCapabilities()
+    probe = ClientCapabilityProbe(_make_params(caps))
+    assert probe.supports_dynamic(()) is False
+
+
+def test_workspace_path() -> None:
+    """Workspace symbol lives at a different root — verify path handling."""
+    caps = lsp.ClientCapabilities(
+        workspace=lsp.WorkspaceClientCapabilities(
+            symbol=lsp.WorkspaceSymbolClientCapabilities(dynamic_registration=True)
+        )
+    )
+    probe = ClientCapabilityProbe(_make_params(caps))
+    assert probe.supports_dynamic(("workspace", "symbol")) is True
+
+
+def test_dict_shape_snake_case() -> None:
+    """A capabilities object whose nested fields are dicts (vendor extension shape)."""
+    params = lsp.InitializeParams(capabilities=lsp.ClientCapabilities())
+    # Replace `_caps` with a hand-built dict graph to simulate raw vendor extensions.
+    probe = ClientCapabilityProbe(params)
+    probe._caps = {  # type: ignore[attr-defined]
+        "text_document": {"hover": {"dynamic_registration": True}}
+    }
+    assert probe.supports_dynamic(("text_document", "hover")) is True
+
+
+def test_dict_shape_camel_case() -> None:
+    params = lsp.InitializeParams(capabilities=lsp.ClientCapabilities())
+    probe = ClientCapabilityProbe(params)
+    probe._caps = {  # type: ignore[attr-defined]
+        "textDocument": {"hover": {"dynamicRegistration": True}}
+    }
+    assert probe.supports_dynamic(("text_document", "hover")) is True
+
+
+def test_dict_shape_camel_case_false() -> None:
+    params = lsp.InitializeParams(capabilities=lsp.ClientCapabilities())
+    probe = ClientCapabilityProbe(params)
+    probe._caps = {  # type: ignore[attr-defined]
+        "textDocument": {"hover": {"dynamicRegistration": False}}
+    }
+    assert probe.supports_dynamic(("text_document", "hover")) is False
+
+
+def test_mixed_dataclass_and_dict() -> None:
+    """Outer attrs object, inner dict (because vendor sent extra keys)."""
+    caps = lsp.ClientCapabilities()
+    caps.text_document = {"hover": {"dynamic_registration": True}}  # type: ignore[assignment]
+    probe = ClientCapabilityProbe(_make_params(caps))
+    assert probe.supports_dynamic(("text_document", "hover")) is True

--- a/tests/test_capabilities/test_registry.py
+++ b/tests/test_capabilities/test_registry.py
@@ -1,0 +1,61 @@
+"""Sanity-check the registry against lsprotocol's actual ServerCapabilities shape.
+
+Cheap in CPU, expensive when broken: a typo in a static_field name would
+silently produce a malformed initialize response the IDE rejects without
+explanation. This guard tests the dataclass contract, not the data values.
+"""
+
+from __future__ import annotations
+
+import attrs
+import lsprotocol.types as lsp
+import pytest
+
+from java_functional_lsp.capabilities.registry import REGISTRY, all_methods
+
+
+def _server_capability_field_names() -> set[str]:
+    return {f.name for f in attrs.fields(lsp.ServerCapabilities)}
+
+
+@pytest.mark.parametrize("entry", REGISTRY, ids=lambda e: e.id_suffix)
+def test_static_field_exists_on_server_capabilities(entry: object) -> None:
+    valid_fields = _server_capability_field_names()
+    assert entry.static_field in valid_fields, (  # type: ignore[attr-defined]
+        f"{entry.id_suffix}: static_field {entry.static_field!r} "  # type: ignore[attr-defined]
+        f"is not a valid lsp.ServerCapabilities kwarg"
+    )
+
+
+@pytest.mark.parametrize("entry", REGISTRY, ids=lambda e: e.id_suffix)
+def test_client_cap_path_is_non_empty(entry: object) -> None:
+    assert entry.client_cap_path, f"{entry.id_suffix}: client_cap_path must be non-empty"  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize("entry", REGISTRY, ids=lambda e: e.id_suffix)
+def test_id_suffix_is_unique(entry: object) -> None:
+    suffixes = [e.id_suffix for e in REGISTRY]
+    assert suffixes.count(entry.id_suffix) == 1, (  # type: ignore[attr-defined]
+        f"id_suffix {entry.id_suffix!r} appears more than once"  # type: ignore[attr-defined]
+    )
+
+
+@pytest.mark.parametrize("entry", REGISTRY, ids=lambda e: e.id_suffix)
+def test_factories_produce_values(entry: object) -> None:
+    static_value = entry.static_value_factory()  # type: ignore[attr-defined]
+    assert static_value is not None
+    reg_options = entry.registration_options_factory()  # type: ignore[attr-defined]
+    assert reg_options is not None
+
+
+def test_all_methods_includes_parents_and_subs() -> None:
+    methods = all_methods()
+    parents = {e.lsp_method for e in REGISTRY}
+    subs = {sub for e in REGISTRY for sub in e.sub_methods}
+    assert parents.issubset(set(methods))
+    assert subs.issubset(set(methods))
+
+
+def test_all_methods_returns_no_duplicates() -> None:
+    methods = all_methods()
+    assert len(methods) == len(set(methods))

--- a/tests/test_capabilities/test_static_builder.py
+++ b/tests/test_capabilities/test_static_builder.py
@@ -1,0 +1,79 @@
+"""Tests for StaticCapabilityBuilder.
+
+The builder always emits text_document_sync + code_action_provider, then layers
+in the negotiated static entries. Each entry maps to a specific kwarg on
+lsp.ServerCapabilities, so the test asserts both presence and value identity.
+"""
+
+from __future__ import annotations
+
+import lsprotocol.types as lsp
+
+from java_functional_lsp.capabilities.registry import REGISTRY, CapabilityEntry
+from java_functional_lsp.capabilities.static_builder import StaticCapabilityBuilder
+
+
+def _by_suffix(suffix: str) -> CapabilityEntry:
+    return next(e for e in REGISTRY if e.id_suffix == suffix)
+
+
+def test_base_capabilities_always_present() -> None:
+    caps = StaticCapabilityBuilder().build(static_entries=())
+    assert caps.text_document_sync is not None
+    assert caps.code_action_provider is not None
+
+
+def test_text_document_sync_shape() -> None:
+    caps = StaticCapabilityBuilder().build(static_entries=())
+    sync = caps.text_document_sync
+    assert isinstance(sync, lsp.TextDocumentSyncOptions)
+    assert sync.open_close is True
+    assert sync.change == lsp.TextDocumentSyncKind.Full
+    assert isinstance(sync.save, lsp.SaveOptions)
+    assert sync.save.include_text is True
+
+
+def test_code_action_options_advertise_quickfix() -> None:
+    caps = StaticCapabilityBuilder().build(static_entries=())
+    code_action = caps.code_action_provider
+    assert isinstance(code_action, lsp.CodeActionOptions)
+    assert code_action.code_action_kinds == [lsp.CodeActionKind.QuickFix]
+
+
+def test_static_entry_sets_simple_boolean_field() -> None:
+    caps = StaticCapabilityBuilder().build(static_entries=(_by_suffix("hover"),))
+    assert caps.hover_provider is True
+
+
+def test_static_entry_sets_options_object() -> None:
+    caps = StaticCapabilityBuilder().build(static_entries=(_by_suffix("completion"),))
+    assert isinstance(caps.completion_provider, lsp.CompletionOptions)
+    assert caps.completion_provider.trigger_characters == ["."]
+
+
+def test_static_entry_signature_help_options() -> None:
+    caps = StaticCapabilityBuilder().build(static_entries=(_by_suffix("signature-help"),))
+    assert isinstance(caps.signature_help_provider, lsp.SignatureHelpOptions)
+    assert caps.signature_help_provider.trigger_characters == ["(", ","]
+    assert caps.signature_help_provider.retrigger_characters == [")"]
+
+
+def test_static_entry_rename_options() -> None:
+    caps = StaticCapabilityBuilder().build(static_entries=(_by_suffix("rename"),))
+    assert isinstance(caps.rename_provider, lsp.RenameOptions)
+    assert caps.rename_provider.prepare_provider is True
+
+
+def test_full_registry_static() -> None:
+    """When *every* entry is static, all per-feature kwargs should be set."""
+    caps = StaticCapabilityBuilder().build(static_entries=REGISTRY)
+    for entry in REGISTRY:
+        assert getattr(caps, entry.static_field) is not None, (
+            f"{entry.id_suffix}: static_field {entry.static_field} should be set"
+        )
+
+
+def test_empty_entries_does_not_set_extra_fields() -> None:
+    caps = StaticCapabilityBuilder().build(static_entries=())
+    for entry in REGISTRY:
+        assert getattr(caps, entry.static_field, None) is None

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import pytest
 
+from java_functional_lsp.capabilities.registry import REGISTRY
+
 
 def _encode_lsp(obj: dict[str, Any]) -> bytes:
     """Encode a JSON-RPC message with Content-Length header."""
@@ -191,31 +193,23 @@ class TestE2EInitialize:
         assert "java-functional" in info.get("name", "").lower()
 
 
-# Wire-format JSON keys for every jdtls-dependent provider in REGISTRY.
-# Kept in sync with src/java_functional_lsp/capabilities/registry.py: each
-# CapabilityEntry.static_field is camelCase'd by lsprotocol's converter on the
-# wire. If REGISTRY grows, this set should too — the assertion in
-# `test_initialize_with_empty_caps_advertises_all_jdtls_features_statically`
-# would otherwise silently let the new feature regress for Claude Code-style
-# clients.
-_JDTLS_PROVIDER_KEYS: frozenset[str] = frozenset(
-    {
-        "completionProvider",
-        "hoverProvider",
-        "definitionProvider",
-        "referencesProvider",
-        "documentSymbolProvider",
-        "callHierarchyProvider",
-        "signatureHelpProvider",
-        "implementationProvider",
-        "typeDefinitionProvider",
-        "declarationProvider",
-        "documentHighlightProvider",
-        "renameProvider",
-        "typeHierarchyProvider",
-        "workspaceSymbolProvider",
-    }
-)
+def _snake_field_to_wire(field: str) -> str:
+    """Convert a ServerCapabilities snake_case field name to the camelCase JSON key.
+
+    Mirrors lsprotocol's converter, which renames `hover_provider` → `hoverProvider`
+    on serialization. Keeping this local (vs importing the converter) avoids
+    coupling tests to lsprotocol internals.
+    """
+    head, *tail = field.split("_")
+    return head + "".join(part.capitalize() for part in tail)
+
+
+# Derived from REGISTRY (single source of truth) so adding a new CapabilityEntry
+# automatically extends the regression assertion in
+# `test_initialize_with_empty_caps_advertises_all_jdtls_features_statically`.
+# A hand-maintained mirror would silently let new features regress for
+# Claude Code-style clients that ignore client/registerCapability.
+_JDTLS_PROVIDER_KEYS: frozenset[str] = frozenset(_snake_field_to_wire(entry.static_field) for entry in REGISTRY)
 
 
 def _initialize_with_caps(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -191,6 +191,160 @@ class TestE2EInitialize:
         assert "java-functional" in info.get("name", "").lower()
 
 
+# Wire-format JSON keys for every jdtls-dependent provider in REGISTRY.
+# Kept in sync with src/java_functional_lsp/capabilities/registry.py: each
+# CapabilityEntry.static_field is camelCase'd by lsprotocol's converter on the
+# wire. If REGISTRY grows, this set should too — the assertion in
+# `test_initialize_with_empty_caps_advertises_all_jdtls_features_statically`
+# would otherwise silently let the new feature regress for Claude Code-style
+# clients.
+_JDTLS_PROVIDER_KEYS: frozenset[str] = frozenset(
+    {
+        "completionProvider",
+        "hoverProvider",
+        "definitionProvider",
+        "referencesProvider",
+        "documentSymbolProvider",
+        "callHierarchyProvider",
+        "signatureHelpProvider",
+        "implementationProvider",
+        "typeDefinitionProvider",
+        "declarationProvider",
+        "documentHighlightProvider",
+        "renameProvider",
+        "typeHierarchyProvider",
+        "workspaceSymbolProvider",
+    }
+)
+
+
+def _initialize_with_caps(
+    proc: subprocess.Popen[bytes], capabilities: dict[str, Any], root_uri: str = "file:///tmp"
+) -> dict[str, Any]:
+    """Send `initialize` + `initialized` with arbitrary client capabilities, return the raw response."""
+    _send(
+        proc,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"processId": None, "capabilities": capabilities, "rootUri": root_uri},
+        },
+    )
+    response = _read_lsp(proc)
+    assert response is not None, "server returned no initialize response"
+    _send(proc, {"jsonrpc": "2.0", "method": "initialized", "params": {}})
+    return response
+
+
+class TestE2ECapabilityNegotiation:
+    """Regression coverage for per-feature static/dynamic capability negotiation.
+
+    Why these go through stdio + pygls (not just `on_initialize()` directly):
+
+    Pure-Python tests of `on_initialize` (test_server.py:782, :815) construct
+    `lsp.InitializeParams` and inspect the returned attrs object — they skip
+    pygls' wire-format JSON deserialization on the way in and lsprotocol's
+    converter on the way out. The bug fixed in PR #86 went undetected for
+    months precisely because the unit-test layer never observed the JSON the
+    client actually sees. Mirrors the rationale for `test_e2e_jdtls.py`:
+    "Unit tests with mocked subprocesses cannot catch JSON-shape regressions
+    because the mocks never parse the bytes."
+
+    Each test below verifies what a real LSP client would see on the wire.
+    """
+
+    def test_initialize_with_empty_caps_advertises_all_jdtls_features_statically(
+        self, server: subprocess.Popen[bytes]
+    ) -> None:
+        """Claude Code-style empty `capabilities` → server must list every jdtls provider statically.
+
+        Claude Code 2.1.x ignores `client/registerCapability` and routes solely
+        from the InitializeResult. If any jdtls feature is omitted here, that
+        feature is unreachable on Claude Code (the original bug — `LSP
+        documentSymbol` returned "No LSP server available for file type: .java"
+        even though the server was running and responsive).
+        """
+        response = _initialize_with_caps(server, capabilities={})
+        caps = response["result"]["capabilities"]
+        missing = sorted(k for k in _JDTLS_PROVIDER_KEYS if caps.get(k) is None)
+        assert not missing, (
+            f"Static InitializeResult is missing jdtls providers {missing}; "
+            "they will be unreachable on clients that don't honor "
+            "client/registerCapability (e.g., Claude Code 2.1.x)."
+        )
+
+    def test_initialize_with_full_dynamic_support_omits_jdtls_features_statically(
+        self, server: subprocess.Popen[bytes]
+    ) -> None:
+        """VS Code-style full `dynamicRegistration` claims → those providers must NOT be in static caps.
+
+        Preserves the PR #44 invariant: when the client supports dynamic
+        registration, defer jdtls features until jdtls actually warms up so
+        the IDE keeps showing its own diagnostic tooltips during the gap.
+        """
+        capabilities = {
+            "textDocument": {
+                "completion": {"dynamicRegistration": True},
+                "hover": {"dynamicRegistration": True},
+                "definition": {"dynamicRegistration": True},
+                "references": {"dynamicRegistration": True},
+                "documentSymbol": {"dynamicRegistration": True},
+                "callHierarchy": {"dynamicRegistration": True},
+                "signatureHelp": {"dynamicRegistration": True},
+                "implementation": {"dynamicRegistration": True},
+                "typeDefinition": {"dynamicRegistration": True},
+                "declaration": {"dynamicRegistration": True},
+                "documentHighlight": {"dynamicRegistration": True},
+                "rename": {"dynamicRegistration": True},
+                "typeHierarchy": {"dynamicRegistration": True},
+            },
+            "workspace": {"symbol": {"dynamicRegistration": True}},
+        }
+        response = _initialize_with_caps(server, capabilities=capabilities)
+        caps = response["result"]["capabilities"]
+        leaked = sorted(k for k in _JDTLS_PROVIDER_KEYS if caps.get(k) is not None)
+        assert not leaked, (
+            f"jdtls providers {leaked} appear in static caps even though the client claimed "
+            "dynamicRegistration for them — this would suppress IDE diagnostic tooltips during "
+            "jdtls warm-up (PR #44 invariant)."
+        )
+        # Always-static caps remain regardless of negotiation outcome.
+        assert caps.get("textDocumentSync") is not None
+        assert caps.get("codeActionProvider") is not None
+
+    def test_per_feature_negotiation_partial_dynamic_support(self, server: subprocess.Popen[bytes]) -> None:
+        """Mixed dynamic claims → server splits per feature, not all-or-nothing.
+
+        Guards against regressions that collapse the negotiation to a single
+        "if any feature claims dynamic, treat all as dynamic" (or the inverse).
+        Hover and definition claim dynamic; everything else does not. The
+        server must omit hover/definition from static caps and keep the rest.
+        """
+        capabilities = {
+            "textDocument": {
+                "hover": {"dynamicRegistration": True},
+                "definition": {"dynamicRegistration": True},
+            }
+        }
+        response = _initialize_with_caps(server, capabilities=capabilities)
+        caps = response["result"]["capabilities"]
+        # Dynamic-claimed: must be absent from static caps.
+        assert caps.get("hoverProvider") is None, (
+            "hoverProvider leaked into static caps despite the client claiming dynamicRegistration"
+        )
+        assert caps.get("definitionProvider") is None, (
+            "definitionProvider leaked into static caps despite the client claiming dynamicRegistration"
+        )
+        # Everything else should still be advertised statically.
+        unclaimed_keys = _JDTLS_PROVIDER_KEYS - {"hoverProvider", "definitionProvider"}
+        missing = sorted(k for k in unclaimed_keys if caps.get(k) is None)
+        assert not missing, (
+            f"Providers {missing} were dropped from static caps even though the client did NOT "
+            "claim dynamicRegistration for them — per-feature split is broken."
+        )
+
+
 class TestE2EDiagnostics:
     def test_diagnostics_on_open(self, server: subprocess.Popen[bytes], tmp_path: Path) -> None:
         """Opening a Java file with null return should produce diagnostics."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -779,19 +779,28 @@ class TestServerInternals:
             server._on_jdtls_diagnostics("file:///a/has%20space.java", [])
         mock_pub.assert_called_once_with("file:///a/has%20space.java")
 
-    def test_init_capabilities_exclude_jdtls_features(self) -> None:
-        """Static capabilities must NOT include hover/definition/references/completion/documentSymbol.
+    def test_init_capabilities_exclude_jdtls_features_when_client_supports_dynamic(self) -> None:
+        """When the client claims dynamicRegistration, jdtls features are deferred (PR #44 invariant).
 
-        These are registered dynamically after jdtls starts, so the IDE doesn't
-        suppress diagnostic tooltips while jdtls is unavailable.
+        Clients like VS Code and IntelliJ-LSP4IJ declare dynamic-registration support;
+        they will pick up our handlers via the later client/registerCapability call,
+        so the static InitializeResult must NOT include hover/definition/etc. Otherwise
+        the IDE's own diagnostic tooltips get suppressed during jdtls warm-up.
         """
         from java_functional_lsp.server import on_initialize
 
+        text_doc_caps = lsp.TextDocumentClientCapabilities(
+            hover=lsp.HoverClientCapabilities(dynamic_registration=True),
+            definition=lsp.DefinitionClientCapabilities(dynamic_registration=True),
+            references=lsp.ReferenceClientCapabilities(dynamic_registration=True),
+            completion=lsp.CompletionClientCapabilities(dynamic_registration=True),
+            document_symbol=lsp.DocumentSymbolClientCapabilities(dynamic_registration=True),
+        )
         result = on_initialize(
             lsp.InitializeParams(
                 process_id=1,
                 root_uri="file:///tmp",
-                capabilities=lsp.ClientCapabilities(),
+                capabilities=lsp.ClientCapabilities(text_document=text_doc_caps),
             )
         )
         caps = result.capabilities
@@ -802,6 +811,33 @@ class TestServerInternals:
         assert caps.references_provider is None
         assert caps.completion_provider is None
         assert caps.document_symbol_provider is None
+
+    def test_init_capabilities_static_when_client_lacks_dynamic_registration(self) -> None:
+        """Clients that don't claim dynamicRegistration get static advertisement.
+
+        This is the Claude Code 2.1.x case — the client ignores
+        client/registerCapability for routing decisions. The server must list
+        every jdtls feature in the InitializeResult so the client's LSP router
+        picks them up.
+        """
+        from java_functional_lsp.server import on_initialize
+
+        result = on_initialize(
+            lsp.InitializeParams(
+                process_id=1,
+                root_uri="file:///tmp",
+                capabilities=lsp.ClientCapabilities(),  # no dynamicRegistration claims
+            )
+        )
+        caps = result.capabilities
+        assert caps.code_action_provider is not None
+        assert caps.text_document_sync is not None
+        assert caps.hover_provider is True
+        assert caps.definition_provider is True
+        assert caps.references_provider is True
+        assert caps.completion_provider is not None  # CompletionOptions object
+        assert caps.document_symbol_provider is True
+        assert caps.workspace_symbol_provider is True
 
     def test_build_jdtls_registrations(self) -> None:
         """_build_jdtls_registrations returns one Registration per jdtls capability, each scoped to java files."""
@@ -856,6 +892,7 @@ class TestServerInternals:
         from unittest.mock import AsyncMock, MagicMock, patch
 
         import java_functional_lsp.server as srv_mod
+        from java_functional_lsp.capabilities import REGISTRY
         from java_functional_lsp.server import server as srv
 
         # Patch both server.feature (to avoid FeatureAlreadyRegisteredError on
@@ -863,7 +900,9 @@ class TestServerInternals:
         mock_reg = AsyncMock(side_effect=Exception("no"))
         mock_feature = MagicMock(return_value=lambda fn: fn)
         old_flag = srv_mod._jdtls_capabilities_registered
+        old_dyn = getattr(srv, "_dynamic_features", ())
         srv_mod._jdtls_capabilities_registered = False
+        srv._dynamic_features = REGISTRY  # type: ignore[attr-defined]
         try:
             with (
                 caplog.at_level(logging.WARNING, logger="java_functional_lsp.server"),
@@ -873,6 +912,7 @@ class TestServerInternals:
                 await srv_mod._register_jdtls_capabilities()
         finally:
             srv_mod._jdtls_capabilities_registered = old_flag
+            srv._dynamic_features = old_dyn  # type: ignore[attr-defined]
         assert any("Failed to dynamically register" in r.getMessage() for r in caplog.records)
 
     async def test_register_jdtls_capabilities_happy_path(self, caplog: Any) -> None:
@@ -881,13 +921,22 @@ class TestServerInternals:
         from unittest.mock import AsyncMock, MagicMock, patch
 
         import java_functional_lsp.server as srv_mod
+        from java_functional_lsp.capabilities import REGISTRY, all_methods
         from java_functional_lsp.server import server as srv
 
         mock_reg = AsyncMock(return_value=None)
         registered_methods: list[str] = []
         mock_feature = MagicMock(side_effect=lambda m: registered_methods.append(m) or (lambda fn: fn))
         old_flag = srv_mod._jdtls_capabilities_registered
+        old_dyn = getattr(srv, "_dynamic_features", ())
+        # The HandlerWiring idempotency guard probes pygls' _features map and skips
+        # already-registered methods. Earlier tests in the same process can leave
+        # those entries populated; remove them so wire_lazy actually invokes the
+        # mocked srv.feature and we can observe the calls.
+        feature_map = srv.protocol.fm._features  # type: ignore[attr-defined]
+        evicted = {m: feature_map.pop(m) for m in all_methods(REGISTRY) if m in feature_map}
         srv_mod._jdtls_capabilities_registered = False
+        srv._dynamic_features = REGISTRY  # type: ignore[attr-defined]
         try:
             with (
                 caplog.at_level(logging.INFO, logger="java_functional_lsp.server"),
@@ -897,6 +946,8 @@ class TestServerInternals:
                 await srv_mod._register_jdtls_capabilities()
         finally:
             srv_mod._jdtls_capabilities_registered = old_flag
+            srv._dynamic_features = old_dyn  # type: ignore[attr-defined]
+            feature_map.update(evicted)
         # Handlers were registered for all methods (including call hierarchy)
         assert lsp.TEXT_DOCUMENT_HOVER in registered_methods
         assert lsp.TEXT_DOCUMENT_COMPLETION in registered_methods
@@ -2107,22 +2158,25 @@ class TestLspLifecycle:
     """Full LSP lifecycle tests via real stdio transport — zero mocks."""
 
     async def test_initialize_reports_capabilities(self, lsp_client: LanguageClient) -> None:
-        """Server advertises codeActionProvider and textDocumentSync but NOT jdtls features.
+        """Server advertises codeActionProvider, textDocumentSync, and jdtls features statically.
 
-        jdtls-dependent capabilities (hover, definition, references, completion,
-        documentSymbol) are registered dynamically after jdtls starts, so they
-        should NOT appear in the static InitializeResult.
+        The lsp_client fixture initializes without claiming dynamicRegistration for
+        any jdtls-gated feature. Per the LSP spec, the server must therefore
+        advertise those features in the static InitializeResult — otherwise
+        clients that ignore client/registerCapability (Claude Code 2.1.x) would
+        never route requests to us.
         """
         caps = lsp_client._server_capabilities  # type: ignore[attr-defined]
         assert caps is not None
         assert caps.code_action_provider is not None
         assert caps.text_document_sync is not None
-        # jdtls features are NOT statically advertised (registered dynamically)
-        assert caps.hover_provider is None
-        assert caps.definition_provider is None
-        assert caps.references_provider is None
-        assert caps.completion_provider is None
-        assert caps.document_symbol_provider is None
+        # jdtls features ARE statically advertised since the client did not
+        # claim dynamicRegistration support.
+        assert caps.hover_provider is True
+        assert caps.definition_provider is True
+        assert caps.references_provider is True
+        assert caps.completion_provider is not None  # CompletionOptions
+        assert caps.document_symbol_provider is True
 
     async def test_null_return_diagnostic_published(self, lsp_client: LanguageClient) -> None:
         """didOpen a file with ``return null`` → server publishes null-return diagnostic."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import pytest
@@ -61,7 +62,7 @@ public class Clean {
 
 
 @pytest.fixture
-async def lsp_client(tmp_path: Any) -> LanguageClient:  # type: ignore[misc]
+async def lsp_client(tmp_path: Any) -> AsyncGenerator[LanguageClient, None]:
     """Spawn the real java-functional-lsp server and return an initialized client.
 
     Uses pygls ``LanguageClient.start_io`` to connect via stdio — the exact
@@ -75,7 +76,7 @@ async def lsp_client(tmp_path: Any) -> LanguageClient:  # type: ignore[misc]
     client._diag_events: dict[str, asyncio.Event] = {}  # type: ignore[attr-defined]
 
     @client.feature(lsp.TEXT_DOCUMENT_PUBLISH_DIAGNOSTICS)
-    def on_publish(params: lsp.PublishDiagnosticsParams) -> None:
+    def _on_publish(params: lsp.PublishDiagnosticsParams) -> None:  # pyright: ignore[reportUnusedFunction]
         client._published[params.uri] = list(params.diagnostics)  # type: ignore[attr-defined]
         evt = client._diag_events.get(params.uri)  # type: ignore[attr-defined]
         if evt is not None:
@@ -673,7 +674,7 @@ class TestServerInternals:
 
         observed_before_await: dict[str, bool] = {}
 
-        async def _spy_send(*_args: Any, **_kwargs: Any) -> None:
+        async def _spy_send(*_args: Any, **_kwargs: Any) -> None:  # pyright: ignore[reportUnusedParameter]
             # This spy is injected as server._proxy.send_notification, which is
             # the first ``await`` reached in the is_available=True branch of
             # on_did_open (line: `await server._proxy.send_notification(...)`).
@@ -1131,7 +1132,7 @@ class TestServerInternals:
         mock_add = AsyncMock(return_value="file:///mod")
         mock_send = AsyncMock(side_effect=[None, {"result": "ok"}])
 
-        async def mock_wait(uri: str, timeout: float = 30.0) -> bool:  # type: ignore[reportUnusedParameter]
+        async def mock_wait(uri: str, timeout: float = 30.0) -> bool:  # pyright: ignore[reportUnusedParameter]
             srv._proxy.modules.mark_ready(uri)
             return True
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -195,6 +195,41 @@ def _ensure_workspace() -> None:
         )
 
 
+def _build_caps_with_dynamic(path: tuple[str, ...]) -> lsp.ClientCapabilities:
+    """Build a ClientCapabilities tree with dynamic_registration=True at the given path.
+
+    `path` mirrors `CapabilityEntry.client_cap_path`. Examples:
+      ("text_document", "hover") → ClientCapabilities with
+          text_document.hover.dynamic_registration = True
+      ("workspace", "symbol") → ClientCapabilities with
+          workspace.symbol.dynamic_registration = True
+
+    The leaf class is discovered by inspecting the parent's type hints (rather
+    than guessing class names) — lsprotocol's naming has irregular cases like
+    `references` → `ReferenceClientCapabilities` (singular) and
+    `workspace.symbol` → `WorkspaceSymbolClientCapabilities` (prefixed root).
+    """
+    import typing
+
+    if path[0] == "text_document":
+        parent_class: type = lsp.TextDocumentClientCapabilities
+        root_kwarg = "text_document"
+    elif path[0] == "workspace":
+        parent_class = lsp.WorkspaceClientCapabilities
+        root_kwarg = "workspace"
+    else:
+        raise ValueError(f"Unsupported client_cap_path root: {path[0]!r}")
+
+    leaf_attr = path[-1]
+    hints = typing.get_type_hints(parent_class)
+    type_hint = hints[leaf_attr]
+    non_none_args = [arg for arg in typing.get_args(type_hint) if arg is not type(None)]
+    leaf_class = non_none_args[0] if non_none_args else type_hint
+
+    leaf = leaf_class(dynamic_registration=True)
+    return lsp.ClientCapabilities(**{root_kwarg: parent_class(**{leaf_attr: leaf})})
+
+
 class TestServerInternals:
     """Direct-call tests for server.py helpers — provides in-process coverage."""
 
@@ -779,38 +814,53 @@ class TestServerInternals:
             server._on_jdtls_diagnostics("file:///a/has%20space.java", [])
         mock_pub.assert_called_once_with("file:///a/has%20space.java")
 
-    def test_init_capabilities_exclude_jdtls_features_when_client_supports_dynamic(self) -> None:
-        """When the client claims dynamicRegistration, jdtls features are deferred (PR #44 invariant).
+    @pytest.mark.parametrize(
+        "entry",
+        list(__import__("java_functional_lsp.capabilities.registry", fromlist=["REGISTRY"]).REGISTRY),
+        ids=lambda e: e.id_suffix,
+    )
+    def test_init_capabilities_exclude_jdtls_feature_when_client_supports_dynamic(self, entry: Any) -> None:
+        """When the client claims dynamicRegistration for one feature, ONLY that feature is deferred.
 
-        Clients like VS Code and IntelliJ-LSP4IJ declare dynamic-registration support;
-        they will pick up our handlers via the later client/registerCapability call,
-        so the static InitializeResult must NOT include hover/definition/etc. Otherwise
-        the IDE's own diagnostic tooltips get suppressed during jdtls warm-up.
+        Parametrized over every CapabilityEntry in REGISTRY so each new jdtls
+        capability gets coverage automatically. For each entry we:
+          1. Construct ClientCapabilities with dynamic_registration=True at the
+             entry's client_cap_path (and nowhere else).
+          2. Assert the entry's static_field is omitted (so the IDE's own
+             diagnostic tooltips are not suppressed during jdtls warm-up — the
+             PR #44 invariant).
+          3. Assert every OTHER entry is still advertised statically (per-feature
+             negotiation, not all-or-nothing).
         """
+        from java_functional_lsp.capabilities.registry import REGISTRY
         from java_functional_lsp.server import on_initialize
 
-        text_doc_caps = lsp.TextDocumentClientCapabilities(
-            hover=lsp.HoverClientCapabilities(dynamic_registration=True),
-            definition=lsp.DefinitionClientCapabilities(dynamic_registration=True),
-            references=lsp.ReferenceClientCapabilities(dynamic_registration=True),
-            completion=lsp.CompletionClientCapabilities(dynamic_registration=True),
-            document_symbol=lsp.DocumentSymbolClientCapabilities(dynamic_registration=True),
-        )
+        caps = _build_caps_with_dynamic(entry.client_cap_path)
         result = on_initialize(
             lsp.InitializeParams(
                 process_id=1,
                 root_uri="file:///tmp",
-                capabilities=lsp.ClientCapabilities(text_document=text_doc_caps),
+                capabilities=caps,
             )
         )
-        caps = result.capabilities
-        assert caps.code_action_provider is not None
-        assert caps.text_document_sync is not None
-        assert caps.hover_provider is None
-        assert caps.definition_provider is None
-        assert caps.references_provider is None
-        assert caps.completion_provider is None
-        assert caps.document_symbol_provider is None
+        server_caps = result.capabilities
+
+        assert getattr(server_caps, entry.static_field) is None, (
+            f"{entry.id_suffix}: client claimed dynamicRegistration, "
+            f"but server still advertised {entry.static_field} statically — "
+            "this would suppress the IDE's diagnostic tooltips during jdtls warm-up."
+        )
+
+        for other in REGISTRY:
+            if other.id_suffix == entry.id_suffix:
+                continue
+            assert getattr(server_caps, other.static_field) is not None, (
+                f"While testing {entry.id_suffix}: {other.static_field} was unexpectedly omitted "
+                "(per-feature negotiation should not affect siblings)."
+            )
+
+        assert server_caps.code_action_provider is not None
+        assert server_caps.text_document_sync is not None
 
     def test_init_capabilities_static_when_client_lacks_dynamic_registration(self) -> None:
         """Clients that don't claim dynamicRegistration get static advertisement.

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "java-functional-lsp"
-version = "0.9.18"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pygls" },


### PR DESCRIPTION
## Summary
- Reads `params.capabilities.textDocument.<feature>.dynamicRegistration` per feature in `on_initialize`. Clients claiming dynamic-registration support get the dynamic path (preserves PR #44 behavior — IDE keeps showing its own diagnostic tooltips while jdtls warms up). Clients that don't get static advertisement so their LSP routing picks up our handlers.
- Fixes Claude Code 2.1.x routing for `.java` files (it doesn't honor `client/registerCapability` for routing). Same negotiation works for any spec-conformant LSP client — zero hardcoded client names.
- Decomposed into a `capabilities/` package with one responsibility per module: `registry.py` (data), `probe.py` (read), `negotiator.py` (decide), `static_builder.py` (assemble `ServerCapabilities`), `handler_wiring.py` (register pygls handlers).
- Bumps version 0.9.18 → 0.10.0 (on-the-wire behavior change, backward-compatible for spec-conformant clients).

Closes #85.

## Test plan
- [x] `pytest tests/` — 633 passed, 86.04% coverage (`capabilities/` package at 94–100%)
- [x] New `tests/test_capabilities/` — 92 cases covering probe (attrs + dict shapes, snake/camel keys), negotiator (split logic), static_builder (ServerCapabilities assembly), handler_wiring (idempotency + sub-method handling), registry (every `static_field` is a real `lsp.ServerCapabilities` kwarg)
- [x] `tests/test_server.py` — added `test_init_capabilities_static_when_client_lacks_dynamic_registration` and renamed the dynamic-supporting case to `_when_client_supports_dynamic`. `test_initialize_reports_capabilities` now asserts statically advertised features
- [x] Local install (`pip install --no-deps -e .`) + Claude Code restart + `LSP documentSymbol` on `DeltaProductType.java` returns symbols (not "No LSP server available")
- [x] Same for `LSP hover` and `LSP goToDefinition`
- [x] VS Code + IntelliJ-LSP4IJ non-regression: hover within first 5s after open still shows custom diagnostic tooltips (PR #44 invariant — both IDEs claim `dynamicRegistration: true`, hit the dynamic path identical to today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)