### PR TITLE
fix: sync __version__ string with pyproject.toml (0.11.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "java-functional-lsp"
-version = "0.11.0"
+version = "0.11.1"
 description = "Java LSP server enforcing functional programming best practices — null safety, immutability, no exceptions"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/java_functional_lsp/__init__.py
+++ b/src/java_functional_lsp/__init__.py
@@ -1,3 +1,3 @@
 """java-functional-lsp: A Java LSP server enforcing functional programming best practices."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.1"


### PR DESCRIPTION
## Summary

PR #88 bumped `pyproject.toml` to `0.11.0` but left `src/java_functional_lsp/__init__.py` at `0.10.0`, so the published `0.11.0` package reported `java-functional-lsp 0.10.0` via `--version`. Functionally fine, but misleading.

Bump both files to `0.11.1` so the next published artifact reports the correct version.

## Test plan

- [x] `uv run java-functional-lsp --version` → `java-functional-lsp 0.11.1`
- [x] `uv run pytest tests/test_server.py -k version_bump_preserves` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)