### PR TITLE
test: guard against __version__ vs pyproject.toml drift

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,26 @@
+"""Regression guard: __version__ in src must equal pyproject.toml's project.version.
+
+PR #88 (v0.11.0) bumped pyproject.toml to 0.11.0 but left __init__.py at 0.10.0,
+shipping a package whose --version output disagreed with its metadata. v0.11.1
+hotfixed it. This test prevents the same drift from recurring.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from java_functional_lsp import __version__
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def test_version_matches_pyproject() -> None:
+    text = PYPROJECT.read_text()
+    match = re.search(r'(?m)^version\s*=\s*"([^"]+)"', text)
+    assert match is not None, f"pyproject.toml at {PYPROJECT} has no top-level version line"
+    pyproject_version = match.group(1)
+    assert __version__ == pyproject_version, (
+        f"java_functional_lsp.__version__={__version__!r} disagrees with "
+        f"pyproject.toml version={pyproject_version!r}. Update both when bumping."
+    )


### PR DESCRIPTION
## Summary

Adds a regression test that asserts `java_functional_lsp.__version__` (from `src/java_functional_lsp/__init__.py`) equals the `version` line in `pyproject.toml`.

## Why

PR #88 (v0.11.0) bumped `pyproject.toml` to `0.11.0` but left `__init__.py` at `0.10.0`. The published package's `--version` output disagreed with its installed metadata. v0.11.1 hotfixed it. This test prevents the same drift from slipping through again — the next single-side bump fails CI before it ships.

## Test plan

- [x] `uv run pytest tests/test_version.py -v --no-cov` → 1 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)